### PR TITLE
fix: lowercase `gqlprune` CLI command + 1.x→2.0 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@
 
 `gqlPrune` is a utility that identifies unused GraphQL operations (queries, mutations, subscriptions) in your project. It scans `.gql`/`.graphql` files for named operations and checks whether they are referenced anywhere in your TypeScript/JavaScript source.
 
+## Migrating from 1.x to 2.0
+
+- **Node.js ≥ 20** is now required.
+- **The CLI command is `gqlprune`** (lowercase), matching the package name — `npx gqlprune` and a global `gqlprune` both work.
+- **Usage detection is broader and configurable.** It now also matches lazy/suspense hooks and the generated `<Name>Document` constant, not just `use<Name><Type>`. If you use a different client (urql, react-query, raw documents, …), set [`usagePatterns`](#configuration) so your operations aren't reported as unused.
+- **Folder exclusion now works as documented.** `excludedFolders` matches by folder name or root-relative path, and `node_modules`/`.git` are always excluded. (In 1.x the documented `node_modules` entry silently did nothing.)
+
 ## How it detects usage
 
 An operation is considered **used** if any of a set of search strings derived from its name appears in your source files. By default `gqlPrune` looks for the conventions emitted by [GraphQL Code Generator](https://the-guild.dev/graphql/codegen) (the `typescript-react-apollo` / near-operation-file presets):

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "This script helps identify unused GraphQL operations (queries, mutations, subscriptions) in your project. It scans .gql files for operations and checks if they are being used in your TypeScript/JavaScript files.",
   "bin": {
-    "gqlPrune": "./dist/cli.js"
+    "gqlprune": "./dist/cli.js"
   },
   "files": [
     "dist",

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -1,0 +1,18 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const pkg = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'),
+) as { name: string; bin: string | Record<string, string> };
+
+describe('package.json', () => {
+  it('names the CLI bin exactly after the package', () => {
+    // Regression guard for the v1 → v2 miss: the docs and package name were
+    // `gqlprune` while the bin key was `gqlPrune`, so a Linux global install
+    // exposed a differently-cased command. The bin name must equal the package
+    // name. (A string `bin` is implicitly named after the package.)
+    const binNames =
+      typeof pkg.bin === 'string' ? [pkg.name] : Object.keys(pkg.bin);
+    expect(binNames).toEqual([pkg.name]);
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix the CLI command casing (closes #10).** The published `bin` was `gqlPrune` while the package and all docs are `gqlprune`, so a global install exposed a differently-cased command than the README showed. Renamed the bin to `gqlprune`. `npx gqlprune` is unaffected, and case-insensitive filesystems (macOS/Windows) still resolve `gqlPrune` too.
- **Add a "Migrating from 1.x to 2.0" section** to the README covering the breaking changes: Node ≥ 20, the lowercase command, broader/configurable usage detection, and folder exclusion now working as documented.

Thanks to @lukemichaeleisenberg for the original report.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * The CLI is now installed and run as `gqlprune` (lowercase).
  * Usage detection behavior is more flexible, with configurable matching (including lazy/suspense hooks and generated `Document` constants).

* **Documentation**
  * Added a “Migrating from 1.x to 2.0” section, covering the Node.js ≥ 20 requirement and clarified that `node_modules`/`.git` are always excluded.

* **Tests**
  * Added a regression test to ensure the published CLI command name matches the package name exactly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->