### PR TITLE
ci: allow on-demand Scorecard runs (workflow_dispatch)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,6 +8,9 @@ on:
     - cron: "27 7 * * 1"
   push:
     branches: [main]
+  # Allow re-scanning on demand (Actions tab → Run workflow) instead of
+  # waiting for the weekly cron.
+  workflow_dispatch:
 
 # Least-privilege by default; the analysis job elevates only what it needs.
 permissions: read-all


### PR DESCRIPTION
Adds `workflow_dispatch` to the Scorecard workflow so the supply-chain scan can be re-triggered from the Actions tab (Actions → Scorecard supply-chain security → Run workflow) instead of waiting for the weekly cron. Handy for refreshing the score after the OpenSSF Best Practices badge flipped to passing and after any branch-protection tightening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for manually starting the Scorecard workflow from the Actions interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->