### PR TITLE
chore: gitignore docs/research/ for local research artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ out
 .pnp.*
 .secrets
 dist/**
+
+# Local research artifacts (kept locally, not committed for now)
+docs/research/


### PR DESCRIPTION
Ignores `docs/research/` so deep-research reports can live on disk for reference without being committed (for now). No source/behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control settings to ignore local research artifacts, keeping them out of commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->