### PR TITLE
feat: detect unused fragments across files (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Krister-Johansson/gqlPrune/badge)](https://scorecard.dev/viewer/?uri=github.com/Krister-Johansson/gqlPrune)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13364/badge)](https://www.bestpractices.dev/projects/13364)
 
-`gqlPrune` is a utility that identifies unused GraphQL operations (queries, mutations, subscriptions) **and unused fragments** in your project. It scans `.gql`/`.graphql` files and checks whether each operation is referenced in your TypeScript/JavaScript source, and whether each fragment is spread by a used document — all without needing a running server or schema.
+`gqlPrune` is a utility that identifies unused GraphQL operations (queries, mutations, subscriptions) **and unused fragments** in your project. It scans `.gql`/`.graphql` files and checks whether each operation is referenced in your TypeScript/JavaScript source, and whether each fragment is spread by an operation or referenced in source — all without needing a running server or schema.
 
 ## Migrating from 1.x to 2.0
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Krister-Johansson/gqlPrune/badge)](https://scorecard.dev/viewer/?uri=github.com/Krister-Johansson/gqlPrune)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13364/badge)](https://www.bestpractices.dev/projects/13364)
 
-`gqlPrune` is a utility that identifies unused GraphQL operations (queries, mutations, subscriptions) in your project. It scans `.gql`/`.graphql` files for named operations and checks whether they are referenced anywhere in your TypeScript/JavaScript source.
+`gqlPrune` is a utility that identifies unused GraphQL operations (queries, mutations, subscriptions) **and unused fragments** in your project. It scans `.gql`/`.graphql` files and checks whether each operation is referenced in your TypeScript/JavaScript source, and whether each fragment is spread by a used document — all without needing a running server or schema.
 
 ## Migrating from 1.x to 2.0
 
@@ -34,6 +34,15 @@ For an operation `query GetUser`, the defaults match:
 | `{Name}Document`         | `GetUserDocument`        |
 
 If your project uses a different convention (urql, react-query, graphql-request, Vue, raw documents, etc.), override the patterns via `usagePatterns` in the config — see below. Without that, operations may be incorrectly reported as unused.
+
+### Unused fragments
+
+`gqlPrune` also reports **fragments that are never used**, across files and without a schema. A fragment is considered **used** when it is either:
+
+- spread (directly or transitively) by **any** operation in your `.gql` corpus, or
+- referenced in your source via a fragment pattern — by default the codegen `<Name>FragmentDoc` constant (e.g. under fragment masking). Override with `fragmentUsagePatterns`.
+
+A fragment spread only by another _unused_ fragment is reported too. Note: a fragment is kept alive by any operation that spreads it, even an unused one — that operation is reported separately, so the fragment surfaces on the next run once you remove the operation.
 
 ## Setup
 
@@ -58,17 +67,22 @@ graphqlDir: ./path/to/graphql
 srcDir: ./src
 excludedFolders:
   - __generated__
-# Optional — override how usage is detected.
+# Optional — override how operation usage is detected.
 # Supports {name}, {Name}, {type}, {Type} placeholders.
 usagePatterns:
   - use{Name}{Type}
   - '{Name}Document'
+# Optional — override how fragments are matched in source (e.g. masking).
+# Supports {name}, {Name} placeholders.
+fragmentUsagePatterns:
+  - '{Name}FragmentDoc'
 ```
 
 - `graphqlDir`: directory containing your `.gql`/`.graphql` files.
 - `srcDir`: directory containing your source files (`.ts`, `.tsx`, `.js`, `.jsx`).
 - `excludedFolders` _(optional)_: folder **names** (e.g. `__generated__`, matched anywhere in the tree) or **paths relative to the project root** (e.g. `src/legacy`). `node_modules` and `.git` are always excluded.
-- `usagePatterns` _(optional)_: templates used to detect usage. Defaults to the table above when omitted.
+- `usagePatterns` _(optional)_: templates used to detect operation usage. Defaults to the table above when omitted.
+- `fragmentUsagePatterns` _(optional)_: templates for detecting fragments referenced directly in source (fragment masking). Defaults to `{Name}FragmentDoc`.
 
 ## Usage
 
@@ -76,10 +90,10 @@ usagePatterns:
 npx gqlprune
 ```
 
-This prints any unused GraphQL operations. The command exits with:
+This prints any unused GraphQL operations and fragments. The command exits with:
 
-- **0** when no unused operations are found (suitable for CI gates).
-- **1** when unused operations are found (or on configuration errors).
+- **0** when nothing unused is found (suitable for CI gates).
+- **1** when unused operations or fragments are found (or on configuration errors).
 
 ### In CI
 
@@ -95,11 +109,16 @@ Add a script and run it in your pipeline; the non-zero exit fails the job when u
 
 ## Output
 
-The utility outputs the operation type, name, and the file where it is defined:
+Unused operations and fragments are listed in separate sections — operations by type, name, and file; fragments by name and file:
 
 ```bash
+--- Unused GraphQL Operations ---
 Type     Operation       File
 query    OperationName   operationFile.gql
+
+--- Unused GraphQL Fragments ---
+Fragment        File
+FragmentName    fragmentFile.gql
 ```
 
 ## Contributing

--- a/src/core/gqlPruner.ts
+++ b/src/core/gqlPruner.ts
@@ -3,6 +3,7 @@ import kleur from 'kleur';
 import * as yaml from 'js-yaml';
 import path from 'path';
 import { OperationInfo } from '../types/OperationInfo.js';
+import { FragmentInfo } from '../types/FragmentInfo.js';
 import { GqlPruneConfig } from '../types/GqlPruneConfig.js';
 import {
   directoryExists,
@@ -12,9 +13,11 @@ import {
 } from '../utils/fileUtils.js';
 import {
   buildUsagePatterns,
+  DEFAULT_FRAGMENT_USAGE_PATTERNS,
   DEFAULT_USAGE_PATTERNS,
 } from '../utils/usagePatterns.js';
 import { extractOperations } from '../utils/operations.js';
+import { findUnusedFragmentsInCorpus } from '../utils/fragments.js';
 
 // Folders that are always excluded from traversal, regardless of config.
 export const DEFAULT_EXCLUDED_FOLDERS = ['node_modules', '.git'];
@@ -44,6 +47,17 @@ export function resolveUsagePatterns(config: GqlPruneConfig): string[] {
 }
 
 /**
+ * Returns the configured fragment usage patterns, falling back to the defaults
+ * when none are provided.
+ */
+export function resolveFragmentUsagePatterns(config: GqlPruneConfig): string[] {
+  return Array.isArray(config.fragmentUsagePatterns) &&
+    config.fragmentUsagePatterns.length > 0
+    ? config.fragmentUsagePatterns
+    : DEFAULT_FRAGMENT_USAGE_PATTERNS;
+}
+
+/**
  * Returns the operations that are not referenced by any of the file contents,
  * using the given usage patterns.
  */
@@ -56,6 +70,62 @@ export function findUnusedOperations(
     const patterns = buildUsagePatterns(op, usagePatterns);
     return !isOperationUsedInContents(patterns, fileContents);
   });
+}
+
+/** Prints the aligned table of unused operations. */
+function reportUnusedOperations(unusedOperations: OperationInfo[]): void {
+  const maxTypeLength = Math.max(
+    'Type'.length,
+    ...unusedOperations.map((op) => op.type.length),
+  );
+  const maxNameLength = Math.max(
+    'Operation'.length,
+    ...unusedOperations.map((op) => op.name.length),
+  );
+
+  console.log(kleur.blue('\n--- Unused GraphQL Operations ---\n'));
+  console.log(
+    'Type'.padEnd(maxTypeLength),
+    'Operation'.padEnd(maxNameLength),
+    'File',
+  );
+  unusedOperations.forEach((op) => {
+    console.log(
+      `${kleur.yellow(op.type.padEnd(maxTypeLength))} ${kleur.cyan(
+        op.name.padEnd(maxNameLength),
+      )} ${kleur.magenta(path.basename(op.filePath))}`,
+    );
+  });
+  console.log(kleur.blue('---------------------------------'));
+  console.log(
+    kleur.red(
+      `Found ${unusedOperations.length} unused GraphQL operations. Please remove them.`,
+    ),
+  );
+}
+
+/** Prints the aligned table of unused fragments. */
+function reportUnusedFragments(unusedFragments: FragmentInfo[]): void {
+  const maxNameLength = Math.max(
+    'Fragment'.length,
+    ...unusedFragments.map((fragment) => fragment.name.length),
+  );
+
+  console.log(kleur.blue('\n--- Unused GraphQL Fragments ---\n'));
+  console.log('Fragment'.padEnd(maxNameLength), 'File');
+  unusedFragments.forEach((fragment) => {
+    console.log(
+      `${kleur.cyan(fragment.name.padEnd(maxNameLength))} ${kleur.magenta(
+        path.basename(fragment.filePath),
+      )}`,
+    );
+  });
+  console.log(kleur.blue('--------------------------------'));
+  console.log(
+    kleur.red(
+      `Found ${unusedFragments.length} unused GraphQL fragments. Please remove them.`,
+    ),
+  );
 }
 
 export function mainFunction() {
@@ -92,6 +162,7 @@ export function mainFunction() {
 
   const excludedFolders = resolveExcludedFolders(config);
   const usagePatterns = resolveUsagePatterns(config);
+  const fragmentUsagePatterns = resolveFragmentUsagePatterns(config);
 
   // ---------------- Main Logic ----------------
 
@@ -127,43 +198,25 @@ export function mainFunction() {
     fileContents,
     usagePatterns,
   );
+  const unusedFragments = findUnusedFragmentsInCorpus(
+    gqlFiles,
+    fileContents,
+    fragmentUsagePatterns,
+  );
 
-  if (unusedOperations.length === 0) {
-    console.log(kleur.green('\n✓ No unused GraphQL operations found.'));
+  if (unusedOperations.length === 0 && unusedFragments.length === 0) {
+    console.log(
+      kleur.green('\n✓ No unused GraphQL operations or fragments found.'),
+    );
     return;
   }
 
-  // Determine the maximum lengths for alignment (header labels included).
-  const maxTypeLength = Math.max(
-    'Type'.length,
-    ...unusedOperations.map((op) => op.type.length),
-  );
-  const maxNameLength = Math.max(
-    'Operation'.length,
-    ...unusedOperations.map((op) => op.name.length),
-  );
+  if (unusedOperations.length > 0) {
+    reportUnusedOperations(unusedOperations);
+  }
+  if (unusedFragments.length > 0) {
+    reportUnusedFragments(unusedFragments);
+  }
 
-  console.log(kleur.blue('\n--- Unused GraphQL Operations ---\n'));
-  console.log(
-    'Type'.padEnd(maxTypeLength),
-    'Operation'.padEnd(maxNameLength),
-    'File',
-  );
-  unusedOperations.forEach((op) => {
-    const type = op.type.padEnd(maxTypeLength);
-    const name = op.name.padEnd(maxNameLength);
-    const fileName = path.basename(op.filePath);
-
-    console.log(
-      `${kleur.yellow(type)} ${kleur.cyan(name)} ${kleur.magenta(fileName)}`,
-    );
-  });
-
-  console.log(kleur.blue('---------------------------------'));
-  console.log(
-    kleur.red(
-      `Found ${unusedOperations.length} unused GraphQL operations. Please remove them.`,
-    ),
-  );
   process.exit(1);
 }

--- a/src/core/gqlPruner.ts
+++ b/src/core/gqlPruner.ts
@@ -47,12 +47,12 @@ export function resolveUsagePatterns(config: GqlPruneConfig): string[] {
 }
 
 /**
- * Returns the configured fragment usage patterns, falling back to the defaults
- * when none are provided.
+ * Returns the configured fragment usage patterns. Falls back to the defaults
+ * only when the option is omitted; an explicit empty array is respected (it
+ * disables source-reference detection, leaving spread-graph reachability only).
  */
 export function resolveFragmentUsagePatterns(config: GqlPruneConfig): string[] {
-  return Array.isArray(config.fragmentUsagePatterns) &&
-    config.fragmentUsagePatterns.length > 0
+  return Array.isArray(config.fragmentUsagePatterns)
     ? config.fragmentUsagePatterns
     : DEFAULT_FRAGMENT_USAGE_PATTERNS;
 }

--- a/src/types/FragmentInfo.d.ts
+++ b/src/types/FragmentInfo.d.ts
@@ -1,0 +1,4 @@
+export type FragmentInfo = {
+  name: string;
+  filePath: string;
+};

--- a/src/types/GqlPruneConfig.d.ts
+++ b/src/types/GqlPruneConfig.d.ts
@@ -13,4 +13,10 @@ export interface GqlPruneConfig {
    * GraphQL Code Generator hook/document conventions when omitted.
    */
   usagePatterns?: string[];
+  /**
+   * Templates used to detect whether a fragment is referenced directly in source
+   * code (e.g. a `<Name>FragmentDoc` constant under fragment masking). Supports
+   * `{name}` / `{Name}` placeholders. Defaults to `{Name}FragmentDoc` when omitted.
+   */
+  fragmentUsagePatterns?: string[];
 }

--- a/src/types/GqlPruneConfig.d.ts
+++ b/src/types/GqlPruneConfig.d.ts
@@ -16,7 +16,9 @@ export interface GqlPruneConfig {
   /**
    * Templates used to detect whether a fragment is referenced directly in source
    * code (e.g. a `<Name>FragmentDoc` constant under fragment masking). Supports
-   * `{name}` / `{Name}` placeholders. Defaults to `{Name}FragmentDoc` when omitted.
+   * `{name}` / `{Name}` placeholders. Defaults to `{Name}FragmentDoc` when
+   * omitted; pass an empty array `[]` to disable source-reference detection and
+   * rely only on fragment-spread reachability.
    */
   fragmentUsagePatterns?: string[];
 }

--- a/src/utils/fragments.ts
+++ b/src/utils/fragments.ts
@@ -74,15 +74,27 @@ export function findUnusedFragmentsInCorpus(
   const allFragments: FragmentInfo[] = [];
   const fragmentSpreads = new Map<string, string[]>();
   const roots = new Set<string>();
+  const seenFragmentNames = new Set<string>();
 
   for (const file of gqlFiles) {
     const entities = extractGraphqlEntities(file);
     entities.operationSpreads.forEach((spread) => roots.add(spread));
     for (const fragment of entities.fragments) {
+      // Fragment names should be unique across the corpus. If they aren't, the
+      // graph is keyed by name, so warn rather than silently conflate them.
+      if (seenFragmentNames.has(fragment.name)) {
+        console.warn(
+          `Warning: duplicate fragment name "${fragment.name}" defined in multiple files; usage results may be approximate.`,
+        );
+      }
+      seenFragmentNames.add(fragment.name);
       allFragments.push(fragment);
     }
     for (const { name, spreads } of entities.fragmentSpreads) {
-      fragmentSpreads.set(name, spreads);
+      // Merge (not overwrite) so a duplicate definition cannot drop spread
+      // edges — over-approximating reachability keeps results conservative.
+      const existing = fragmentSpreads.get(name) ?? [];
+      fragmentSpreads.set(name, [...new Set([...existing, ...spreads])]);
     }
   }
 

--- a/src/utils/fragments.ts
+++ b/src/utils/fragments.ts
@@ -1,0 +1,101 @@
+import { FragmentInfo } from '../types/FragmentInfo.js';
+import { extractGraphqlEntities } from './operations.js';
+import { isOperationUsedInContents } from './fileUtils.js';
+import {
+  buildFragmentPatterns,
+  DEFAULT_FRAGMENT_USAGE_PATTERNS,
+} from './usagePatterns.js';
+
+/**
+ * Computes the set of fragment names reachable from the given roots by walking
+ * the fragment-spread graph. Cycle-safe.
+ *
+ * @param {Iterable<string>} roots - Fragment names that are known to be used.
+ * @param {Map<string, string[]>} fragmentSpreads - Each fragment's direct spreads.
+ * @returns {Set<string>} - All reachable fragment names (including the roots).
+ */
+export function reachableFragments(
+  roots: Iterable<string>,
+  fragmentSpreads: Map<string, string[]>,
+): Set<string> {
+  const reachable = new Set<string>();
+  const stack = [...roots];
+  while (stack.length > 0) {
+    const name = stack.pop() as string;
+    if (reachable.has(name)) {
+      continue;
+    }
+    reachable.add(name);
+    for (const dependency of fragmentSpreads.get(name) ?? []) {
+      stack.push(dependency);
+    }
+  }
+  return reachable;
+}
+
+/**
+ * Returns the fragments that are not reachable from any root.
+ *
+ * @param {FragmentInfo[]} allFragments - Every fragment defined in the corpus.
+ * @param {Iterable<string>} roots - Fragment names known to be used.
+ * @param {Map<string, string[]>} fragmentSpreads - Each fragment's direct spreads.
+ * @returns {FragmentInfo[]} - The unused (unreachable) fragments.
+ */
+export function findUnusedFragments(
+  allFragments: FragmentInfo[],
+  roots: Iterable<string>,
+  fragmentSpreads: Map<string, string[]>,
+): FragmentInfo[] {
+  const reachable = reachableFragments(roots, fragmentSpreads);
+  return allFragments.filter((fragment) => !reachable.has(fragment.name));
+}
+
+/**
+ * Scans the GraphQL corpus and returns fragments that are unused — i.e. neither
+ * (a) reachable via fragment spreads from any operation, nor (b) referenced in
+ * the application source (e.g. a `<Name>FragmentDoc` constant under fragment
+ * masking). Schema-free.
+ *
+ * Note: a fragment is considered used as soon as any operation spreads it, even
+ * if that operation is itself unused — that operation is reported separately, so
+ * this avoids flagging a fragment that becomes orphaned only after the operation
+ * is deleted (caught on the next run).
+ *
+ * @param {string[]} gqlFiles - The `.gql`/`.graphql` files to analyze.
+ * @param {string[]} fileContents - The already-read source file contents.
+ * @param {string[]} fragmentUsagePatterns - Templates for source references.
+ * @returns {FragmentInfo[]} - The unused fragments across the corpus.
+ */
+export function findUnusedFragmentsInCorpus(
+  gqlFiles: string[],
+  fileContents: string[],
+  fragmentUsagePatterns: string[] = DEFAULT_FRAGMENT_USAGE_PATTERNS,
+): FragmentInfo[] {
+  const allFragments: FragmentInfo[] = [];
+  const fragmentSpreads = new Map<string, string[]>();
+  const roots = new Set<string>();
+
+  for (const file of gqlFiles) {
+    const entities = extractGraphqlEntities(file);
+    entities.operationSpreads.forEach((spread) => roots.add(spread));
+    for (const fragment of entities.fragments) {
+      allFragments.push(fragment);
+    }
+    for (const { name, spreads } of entities.fragmentSpreads) {
+      fragmentSpreads.set(name, spreads);
+    }
+  }
+
+  // (b) A fragment referenced directly in source (fragment masking) is a root.
+  for (const fragment of allFragments) {
+    const patterns = buildFragmentPatterns(
+      fragment.name,
+      fragmentUsagePatterns,
+    );
+    if (isOperationUsedInContents(patterns, fileContents)) {
+      roots.add(fragment.name);
+    }
+  }
+
+  return findUnusedFragments(allFragments, roots, fragmentSpreads);
+}

--- a/src/utils/operations.ts
+++ b/src/utils/operations.ts
@@ -1,30 +1,77 @@
 import * as fs from 'fs';
-import { parse } from 'graphql';
+import { ASTNode, parse, visit } from 'graphql';
 import { OperationInfo } from '../types/OperationInfo.js';
+import { FragmentInfo } from '../types/FragmentInfo.js';
+
+export type GraphqlFileEntities = {
+  operations: OperationInfo[];
+  fragments: FragmentInfo[];
+  /** Names of fragments spread (directly or nested) by operations in the file. */
+  operationSpreads: string[];
+  /** Per-fragment direct fragment-spread dependencies. */
+  fragmentSpreads: { name: string; spreads: string[] }[];
+};
 
 /**
- * Extracts GraphQL operations (queries, mutations, etc.) from a given file.
+ * Returns the names of all fragment spreads (`...Name`) within a node, including
+ * those nested in sub-selections and inline fragments. De-duplicated.
+ *
+ * @param {ASTNode} node - A parsed GraphQL AST node (operation or fragment).
+ * @returns {string[]} - The fragment-spread names found within the node.
+ */
+export function getFragmentSpreads(node: ASTNode): string[] {
+  const names = new Set<string>();
+  visit(node, {
+    FragmentSpread(spread) {
+      names.add(spread.name.value);
+    },
+  });
+  return [...names];
+}
+
+/**
+ * Parses a GraphQL file and extracts its named operations, fragment
+ * definitions, and the fragment-spread edges between them. Schema-free.
  *
  * @param {string} filePath - The path to the GraphQL file.
- * @returns {OperationInfo[]} - An array of extracted operations with their name, type, and file path.
+ * @returns {GraphqlFileEntities} - Operations, fragments, and spread edges.
  */
-export function extractOperations(filePath: string): OperationInfo[] {
+export function extractGraphqlEntities(filePath: string): GraphqlFileEntities {
   try {
     const content = fs.readFileSync(filePath, 'utf-8');
     const ast = parse(content);
     const operations: OperationInfo[] = [];
+    const fragments: FragmentInfo[] = [];
+    const operationSpreads = new Set<string>();
+    const fragmentSpreads: { name: string; spreads: string[] }[] = [];
 
     ast.definitions.forEach((definition) => {
-      if (definition.kind === 'OperationDefinition' && definition.name) {
-        operations.push({
+      if (definition.kind === 'OperationDefinition') {
+        if (definition.name) {
+          operations.push({
+            name: definition.name.value,
+            type: definition.operation,
+            filePath,
+          });
+        }
+        // Spreads from every operation (named or anonymous) keep their
+        // fragments alive, so they all count as reachability roots.
+        getFragmentSpreads(definition).forEach((s) => operationSpreads.add(s));
+      } else if (definition.kind === 'FragmentDefinition') {
+        fragments.push({ name: definition.name.value, filePath });
+        fragmentSpreads.push({
           name: definition.name.value,
-          type: definition.operation,
-          filePath,
+          spreads: getFragmentSpreads(definition),
         });
       }
     });
 
-    return operations;
+    return {
+      operations,
+      fragments,
+      operationSpreads: [...operationSpreads],
+      fragmentSpreads,
+    };
   } catch (error) {
     console.error(`Error parsing GraphQL file: ${filePath}`);
     if (error instanceof Error) {
@@ -32,6 +79,21 @@ export function extractOperations(filePath: string): OperationInfo[] {
     } else {
       console.error(error);
     }
-    return [];
+    return {
+      operations: [],
+      fragments: [],
+      operationSpreads: [],
+      fragmentSpreads: [],
+    };
   }
+}
+
+/**
+ * Extracts GraphQL operations (queries, mutations, subscriptions) from a file.
+ *
+ * @param {string} filePath - The path to the GraphQL file.
+ * @returns {OperationInfo[]} - The named operations defined in the file.
+ */
+export function extractOperations(filePath: string): OperationInfo[] {
+  return extractGraphqlEntities(filePath).operations;
 }

--- a/src/utils/usagePatterns.ts
+++ b/src/utils/usagePatterns.ts
@@ -50,3 +50,31 @@ export function buildUsagePatterns(
 ): string[] {
   return [...new Set(patterns.map((pattern) => expandPattern(pattern, op)))];
 }
+
+/**
+ * Default patterns used to detect whether a fragment is referenced directly in
+ * source code — e.g. GraphQL Code Generator's `<Name>FragmentDoc` constant under
+ * fragment masking. Only `{name}` / `{Name}` placeholders apply (fragments have
+ * no operation type). Override via `fragmentUsagePatterns` in the config.
+ */
+export const DEFAULT_FRAGMENT_USAGE_PATTERNS = ['{Name}FragmentDoc'];
+
+/**
+ * Builds the de-duplicated list of concrete search strings used to determine
+ * whether a fragment is referenced in source code.
+ */
+export function buildFragmentPatterns(
+  fragmentName: string,
+  patterns: string[] = DEFAULT_FRAGMENT_USAGE_PATTERNS,
+): string[] {
+  const capitalized = capitalizeFirstLetter(fragmentName);
+  return [
+    ...new Set(
+      patterns.map((pattern) =>
+        pattern
+          .replace(/\{Name\}/g, capitalized)
+          .replace(/\{name\}/g, fragmentName),
+      ),
+    ),
+  ];
+}

--- a/test/fragments.test.ts
+++ b/test/fragments.test.ts
@@ -1,0 +1,134 @@
+import * as fs from 'fs';
+import {
+  findUnusedFragments,
+  findUnusedFragmentsInCorpus,
+  reachableFragments,
+} from '../src/utils/fragments';
+import { FragmentInfo } from '../src/types/FragmentInfo';
+
+jest.mock('fs');
+
+let originalConsoleError: typeof console.error;
+beforeAll(() => {
+  originalConsoleError = console.error;
+  console.error = jest.fn();
+});
+afterAll(() => {
+  console.error = originalConsoleError;
+});
+
+const frag = (name: string, filePath = 'x.gql'): FragmentInfo => ({
+  name,
+  filePath,
+});
+
+describe('fragments', () => {
+  describe('reachableFragments', () => {
+    const graph = new Map<string, string[]>([
+      ['A', ['B']],
+      ['B', ['C']],
+      ['C', []],
+      ['D', ['E']],
+      ['E', ['D']], // cycle
+    ]);
+
+    it('reaches direct and transitive fragments from a root', () => {
+      expect([...reachableFragments(['A'], graph)].sort()).toEqual([
+        'A',
+        'B',
+        'C',
+      ]);
+    });
+
+    it('supports multiple roots', () => {
+      expect([...reachableFragments(['A', 'D'], graph)].sort()).toEqual([
+        'A',
+        'B',
+        'C',
+        'D',
+        'E',
+      ]);
+    });
+
+    it('terminates on cycles', () => {
+      expect([...reachableFragments(['D'], graph)].sort()).toEqual(['D', 'E']);
+    });
+
+    it('returns empty for no roots', () => {
+      expect(reachableFragments([], graph).size).toBe(0);
+    });
+
+    it('handles a root with no graph entry (dangling spread) safely', () => {
+      expect([...reachableFragments(['Ghost'], graph)]).toEqual(['Ghost']);
+    });
+  });
+
+  describe('findUnusedFragments', () => {
+    const all = [frag('A'), frag('B'), frag('C'), frag('Orphan')];
+    const graph = new Map<string, string[]>([
+      ['A', ['B']],
+      ['B', ['C']],
+      ['C', []],
+      ['Orphan', []],
+    ]);
+
+    it('returns fragments not reachable from the roots', () => {
+      expect(findUnusedFragments(all, ['A'], graph)).toEqual([frag('Orphan')]);
+    });
+
+    it('returns all fragments when there are no roots', () => {
+      expect(findUnusedFragments(all, [], graph)).toEqual(all);
+    });
+
+    it('returns none when every fragment is reachable', () => {
+      expect(findUnusedFragments(all, ['A', 'Orphan'], graph)).toEqual([]);
+    });
+  });
+
+  describe('findUnusedFragmentsInCorpus', () => {
+    afterEach(() => jest.resetAllMocks());
+
+    it('flags a fragment no operation spreads and no source references', () => {
+      (fs.readFileSync as jest.Mock).mockImplementation((p: string) => {
+        if (p === 'ops.gql') return 'query Q { ...Used }';
+        return 'fragment Used on T { id }\nfragment Dead on T { id }';
+      });
+      const unused = findUnusedFragmentsInCorpus(
+        ['ops.gql', 'frags.gql'],
+        [],
+        ['{Name}FragmentDoc'],
+      );
+      expect(unused.map((f) => f.name)).toEqual(['Dead']);
+    });
+
+    it('treats a fragment referenced in source (masking) as used', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        'fragment Masked on T { id }',
+      );
+      const unused = findUnusedFragmentsInCorpus(
+        ['f.gql'],
+        ['const x = MaskedFragmentDoc;'],
+        ['{Name}FragmentDoc'],
+      );
+      expect(unused).toEqual([]);
+    });
+
+    it('follows transitive spreads (fragment used only by a used fragment)', () => {
+      (fs.readFileSync as jest.Mock).mockImplementation((p: string) => {
+        if (p === 'ops.gql') return 'query Q { ...Outer }';
+        return 'fragment Outer on T { ...Inner }\nfragment Inner on T { id }\nfragment Lonely on T { id }';
+      });
+      const unused = findUnusedFragmentsInCorpus(
+        ['ops.gql', 'frags.gql'],
+        [],
+        ['{Name}FragmentDoc'],
+      );
+      expect(unused.map((f) => f.name)).toEqual(['Lonely']);
+    });
+
+    it('returns [] when there are no fragments', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue('query Q { id }');
+      expect(findUnusedFragmentsInCorpus(['ops.gql'], [], [])).toEqual([]);
+    });
+  });
+});

--- a/test/fragments.test.ts
+++ b/test/fragments.test.ts
@@ -9,12 +9,16 @@ import { FragmentInfo } from '../src/types/FragmentInfo';
 jest.mock('fs');
 
 let originalConsoleError: typeof console.error;
+let originalConsoleWarn: typeof console.warn;
 beforeAll(() => {
   originalConsoleError = console.error;
+  originalConsoleWarn = console.warn;
   console.error = jest.fn();
+  console.warn = jest.fn();
 });
 afterAll(() => {
   console.error = originalConsoleError;
+  console.warn = originalConsoleWarn;
 });
 
 const frag = (name: string, filePath = 'x.gql'): FragmentInfo => ({
@@ -129,6 +133,30 @@ describe('fragments', () => {
     it('returns [] when there are no fragments', () => {
       (fs.readFileSync as jest.Mock).mockReturnValue('query Q { id }');
       expect(findUnusedFragmentsInCorpus(['ops.gql'], [], [])).toEqual([]);
+    });
+
+    it('warns on duplicate fragment names and merges their spread edges', () => {
+      // a.gql's Dupe spreads OnlyInA; b.gql's Dupe (same name) spreads nothing.
+      // Without merging, the later definition would drop the edge to OnlyInA and
+      // wrongly flag it as unused. Merging keeps it reachable (conservative).
+      (fs.readFileSync as jest.Mock).mockImplementation((p: string) => {
+        if (p === 'a.gql') {
+          return 'fragment Dupe on T { ...OnlyInA }\nfragment OnlyInA on T { id }';
+        }
+        return 'query Q { ...Dupe }\nfragment Dupe on T { id }';
+      });
+      (console.warn as jest.Mock).mockClear();
+
+      const unused = findUnusedFragmentsInCorpus(
+        ['a.gql', 'b.gql'],
+        [],
+        ['{Name}FragmentDoc'],
+      );
+
+      expect(unused.map((f) => f.name)).not.toContain('OnlyInA');
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('duplicate fragment name "Dupe"'),
+      );
     });
   });
 });

--- a/test/gqlPruner.test.ts
+++ b/test/gqlPruner.test.ts
@@ -115,6 +115,16 @@ describe('gqlPruner', () => {
         }),
       ).toEqual(['{Name}FragmentDoc', '{Name}']);
     });
+
+    it('respects an explicit empty array (disables source detection)', () => {
+      expect(
+        resolveFragmentUsagePatterns({
+          graphqlDir: 'g',
+          srcDir: 's',
+          fragmentUsagePatterns: [],
+        }),
+      ).toEqual([]);
+    });
   });
 
   describe('findUnusedOperations', () => {

--- a/test/gqlPruner.test.ts
+++ b/test/gqlPruner.test.ts
@@ -1,14 +1,19 @@
 import * as fs from 'fs';
 import * as fileUtils from '../src/utils/fileUtils';
 import { extractOperations } from '../src/utils/operations';
+import * as fragments from '../src/utils/fragments';
 import {
   DEFAULT_EXCLUDED_FOLDERS,
   findUnusedOperations,
   mainFunction,
   resolveExcludedFolders,
+  resolveFragmentUsagePatterns,
   resolveUsagePatterns,
 } from '../src/core/gqlPruner';
-import { DEFAULT_USAGE_PATTERNS } from '../src/utils/usagePatterns';
+import {
+  DEFAULT_FRAGMENT_USAGE_PATTERNS,
+  DEFAULT_USAGE_PATTERNS,
+} from '../src/utils/usagePatterns';
 import { OperationInfo } from '../src/types/OperationInfo';
 
 jest.mock('fs');
@@ -26,11 +31,16 @@ jest.mock('../src/utils/fileUtils', () => {
 jest.mock('../src/utils/operations', () => ({
   extractOperations: jest.fn(),
 }));
+jest.mock('../src/utils/fragments', () => ({
+  findUnusedFragmentsInCorpus: jest.fn(() => []),
+}));
 
 const mockedDirExists = fileUtils.directoryExists as jest.Mock;
 const mockedFind = fileUtils.findFilesWithExtension as jest.Mock;
 const mockedRead = fileUtils.readFileContents as jest.Mock;
 const mockedExtract = extractOperations as jest.Mock;
+const mockedUnusedFragments =
+  fragments.findUnusedFragmentsInCorpus as jest.Mock;
 
 describe('gqlPruner', () => {
   describe('resolveExcludedFolders', () => {
@@ -86,6 +96,24 @@ describe('gqlPruner', () => {
           usagePatterns: ['{Name}'],
         }),
       ).toEqual(['{Name}']);
+    });
+  });
+
+  describe('resolveFragmentUsagePatterns', () => {
+    it('defaults when not provided', () => {
+      expect(
+        resolveFragmentUsagePatterns({ graphqlDir: 'g', srcDir: 's' }),
+      ).toEqual(DEFAULT_FRAGMENT_USAGE_PATTERNS);
+    });
+
+    it('uses configured patterns when provided', () => {
+      expect(
+        resolveFragmentUsagePatterns({
+          graphqlDir: 'g',
+          srcDir: 's',
+          fragmentUsagePatterns: ['{Name}FragmentDoc', '{Name}'],
+        }),
+      ).toEqual(['{Name}FragmentDoc', '{Name}']);
     });
   });
 
@@ -205,6 +233,44 @@ describe('gqlPruner', () => {
       expect(() => mainFunction()).not.toThrow();
       expect(exitSpy).not.toHaveBeenCalled();
       expect(logged()).toContain('No unused');
+    });
+
+    it('exits 1 and lists unused fragments even when operations are clean', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        'graphqlDir: ./g\nsrcDir: ./s\n',
+      );
+      mockedDirExists.mockReturnValue(true);
+      mockedFind
+        .mockReturnValueOnce(['a.gql'])
+        .mockReturnValueOnce(['App.tsx']);
+      mockedExtract.mockReturnValue([]); // no operations at all
+      mockedRead.mockReturnValue(['']);
+      mockedUnusedFragments.mockReturnValueOnce([
+        { name: 'DeadFragment', filePath: 'a.gql' },
+      ]);
+
+      expect(() => mainFunction()).toThrow('process.exit:1');
+      expect(logged()).toContain('DeadFragment');
+      expect(logged()).toContain('unused GraphQL fragments');
+    });
+
+    it('passes gqlFiles, source contents, and fragment patterns to the corpus scan', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        'graphqlDir: ./g\nsrcDir: ./s\nfragmentUsagePatterns:\n  - "{Name}FragmentDoc"\n',
+      );
+      mockedDirExists.mockReturnValue(true);
+      mockedFind
+        .mockReturnValueOnce(['a.gql'])
+        .mockReturnValueOnce(['App.tsx']);
+      mockedExtract.mockReturnValue([]);
+      mockedRead.mockReturnValue(['source']);
+
+      expect(() => mainFunction()).not.toThrow();
+      expect(mockedUnusedFragments).toHaveBeenCalledWith(
+        ['a.gql'],
+        ['source'],
+        ['{Name}FragmentDoc'],
+      );
     });
   });
 });

--- a/test/operations.test.ts
+++ b/test/operations.test.ts
@@ -1,5 +1,10 @@
 import * as fs from 'fs';
-import { extractOperations } from '../src/utils/operations';
+import { parse } from 'graphql';
+import {
+  extractGraphqlEntities,
+  extractOperations,
+  getFragmentSpreads,
+} from '../src/utils/operations';
 
 jest.mock('fs');
 
@@ -57,6 +62,63 @@ describe('operationUtils', () => {
 
       const operations = extractOperations('./mockFile.gql');
       expect(operations).toEqual([]);
+    });
+  });
+
+  describe('getFragmentSpreads', () => {
+    it('collects spreads including nested and inline fragments', () => {
+      const op = parse('query Q { a { ...F } ... on T { ...G } ...H }')
+        .definitions[0];
+      expect(getFragmentSpreads(op).sort()).toEqual(['F', 'G', 'H']);
+    });
+
+    it('returns an empty array when there are no spreads', () => {
+      const fragment = parse('fragment X on T { id }').definitions[0];
+      expect(getFragmentSpreads(fragment)).toEqual([]);
+    });
+  });
+
+  describe('extractGraphqlEntities', () => {
+    it('extracts operations, fragments, and spread edges', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        'query GetUser { ...UserFields }\n' +
+          'fragment UserFields on User { id ...Inner }\n' +
+          'fragment Inner on User { name }',
+      );
+      const r = extractGraphqlEntities('f.gql');
+      expect(r.operations).toEqual([
+        { name: 'GetUser', type: 'query', filePath: 'f.gql' },
+      ]);
+      expect(r.fragments.map((f) => f.name).sort()).toEqual([
+        'Inner',
+        'UserFields',
+      ]);
+      expect(r.operationSpreads).toEqual(['UserFields']);
+      expect(r.fragmentSpreads).toEqual(
+        expect.arrayContaining([
+          { name: 'UserFields', spreads: ['Inner'] },
+          { name: 'Inner', spreads: [] },
+        ]),
+      );
+    });
+
+    it('collects spreads from anonymous operations too', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        'query { ...Anon }\nfragment Anon on T { id }',
+      );
+      const r = extractGraphqlEntities('f.gql');
+      expect(r.operations).toEqual([]); // anonymous op is not a named operation
+      expect(r.operationSpreads).toEqual(['Anon']); // but its spread still counts
+    });
+
+    it('returns an empty structure on parse error', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue('query Broken {');
+      expect(extractGraphqlEntities('f.gql')).toEqual({
+        operations: [],
+        fragments: [],
+        operationSpreads: [],
+        fragmentSpreads: [],
+      });
     });
   });
 });

--- a/test/usagePatterns.test.ts
+++ b/test/usagePatterns.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_USAGE_PATTERNS,
+  buildFragmentPatterns,
   buildUsagePatterns,
   expandPattern,
 } from '../src/utils/usagePatterns';
@@ -45,6 +46,24 @@ describe('usagePatterns', () => {
       expect(buildUsagePatterns(op)).toEqual(
         buildUsagePatterns(op, DEFAULT_USAGE_PATTERNS),
       );
+    });
+  });
+
+  describe('buildFragmentPatterns', () => {
+    it('expands {Name} and {name} placeholders', () => {
+      expect(
+        buildFragmentPatterns('userFields', ['{Name}FragmentDoc', '{name}']),
+      ).toEqual(['UserFieldsFragmentDoc', 'userFields']);
+    });
+
+    it('defaults to {Name}FragmentDoc', () => {
+      expect(buildFragmentPatterns('userFields')).toEqual([
+        'UserFieldsFragmentDoc',
+      ]);
+    });
+
+    it('de-duplicates expanded patterns', () => {
+      expect(buildFragmentPatterns('x', ['{Name}', '{Name}'])).toEqual(['X']);
     });
   });
 });


### PR DESCRIPTION
Implements **#26** — schema-free, cross-file **unused-fragment** detection, the flagship gap from the competitive research (every existing tool needs a schema and/or sibling context, and the one tool that did this was archived).

## What it does
A fragment is reported **unused** unless it is either:
- spread (directly or transitively) by **any** operation in the `.gql` corpus, or
- referenced in source via a configurable pattern (default `{Name}FragmentDoc`, for fragment masking).

Cross-file, no running server/schema. Cycles, diamonds, transitive chains, and dangling spreads are all handled.

## Changes
- New `src/utils/fragments.ts` — pure `reachableFragments` / `findUnusedFragments` + corpus orchestrator `findUnusedFragmentsInCorpus`; new `FragmentInfo` type.
- `operations.ts` — `extractGraphqlEntities` (operations + fragments + spread graph in one parse); `extractOperations` now delegates; `getFragmentSpreads`.
- `usagePatterns.ts` — `DEFAULT_FRAGMENT_USAGE_PATTERNS` + `buildFragmentPatterns`.
- `gqlPruner` — new "Unused GraphQL Fragments" section; exits 1 when operations **or** fragments are unused; `fragmentUsagePatterns` config option.
- README updated.

## Quality (built TDD)
- Tests **47 → 71**; coverage ~98% statements / 100% functions (threshold gate passes).
- Verified end-to-end against a multi-file fixture (operation-spread, transitive, source-masked, and dead fragments).

Conservative by design: a fragment kept alive only by an *unused* operation is not flagged (that operation is reported separately) — avoids false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for identifying and reporting unused GraphQL fragments alongside unused operations.
  * Added configurable source-level fragment reference detection via `fragmentUsagePatterns`, including placeholder expansion behavior.

* **Bug Fixes**
  * Improved GraphQL analysis to follow fragment dependencies transitively with cycle-safe reachability.
  * Updated CLI output to clearly separate unused operations and unused fragments, including correct non-zero exit behavior on config/validation errors.

* **Documentation**
  * Updated README with new “Unused fragments” details and revised output/usage instructions for fragments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->