### PR TITLE
feat: --json report output + definition line numbers (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,28 @@ This prints any unused GraphQL operations and fragments. The command exits with:
 - **0** when nothing unused is found (suitable for CI gates).
 - **1** when unused operations or fragments are found (or on configuration errors).
 
+### JSON output
+
+Pass `--json` for a machine-readable report (CI, dashboards, scripting) instead of the human-readable tables:
+
+```bash
+npx gqlprune --json
+```
+
+```json
+{
+  "unusedOperations": [
+    { "name": "GetUser", "type": "query", "file": "graphql/user.gql", "line": 1 }
+  ],
+  "unusedFragments": [
+    { "name": "UserFields", "file": "graphql/user.gql", "line": 8 }
+  ],
+  "summary": { "unusedOperations": 1, "unusedFragments": 1 }
+}
+```
+
+Only the JSON is written to stdout and the exit code is unchanged (0 clean / 1 unused), so it pipes cleanly into `jq` and CI gates.
+
 ### In CI
 
 Add a script and run it in your pipeline; the non-zero exit fails the job when unused operations are found:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 import { generateConfig } from './core/configGenerator.js';
 import { mainFunction } from './core/gqlPruner.js';
+import { parseArgs } from './utils/args.js';
 
-const [command] = process.argv.slice(2);
+const { command, json } = parseArgs(process.argv.slice(2));
 
 switch (command) {
   case 'init':
     generateConfig();
     break;
   default:
-    mainFunction();
+    mainFunction({ json });
     break;
 }

--- a/src/core/gqlPruner.ts
+++ b/src/core/gqlPruner.ts
@@ -128,7 +128,44 @@ function reportUnusedFragments(unusedFragments: FragmentInfo[]): void {
   );
 }
 
-export function mainFunction() {
+/** The machine-readable report emitted by `--json`. */
+export type JsonReport = {
+  unusedOperations: {
+    name: string;
+    type: string;
+    file: string;
+    line?: number;
+  }[];
+  unusedFragments: { name: string; file: string; line?: number }[];
+  summary: { unusedOperations: number; unusedFragments: number };
+};
+
+/** Builds the structured report for `--json` output. */
+export function buildJsonReport(
+  unusedOperations: OperationInfo[],
+  unusedFragments: FragmentInfo[],
+): JsonReport {
+  return {
+    unusedOperations: unusedOperations.map((op) => ({
+      name: op.name,
+      type: op.type,
+      file: op.filePath,
+      line: op.line,
+    })),
+    unusedFragments: unusedFragments.map((fragment) => ({
+      name: fragment.name,
+      file: fragment.filePath,
+      line: fragment.line,
+    })),
+    summary: {
+      unusedOperations: unusedOperations.length,
+      unusedFragments: unusedFragments.length,
+    },
+  };
+}
+
+export function mainFunction(options: { json?: boolean } = {}) {
+  const json = options.json ?? false;
   let config: GqlPruneConfig;
 
   try {
@@ -173,21 +210,27 @@ export function mainFunction() {
   );
   const allOperations: OperationInfo[] = gqlFiles.flatMap(extractOperations);
 
-  console.log(
-    `Found ${kleur.yellow(gqlFiles.length.toString())} GraphQL files.`,
-  );
-  console.log(
-    `Found ${kleur.yellow(
-      allOperations.length.toString(),
-    )} GraphQL operations.`,
-  );
+  if (!json) {
+    console.log(
+      `Found ${kleur.yellow(gqlFiles.length.toString())} GraphQL files.`,
+    );
+    console.log(
+      `Found ${kleur.yellow(
+        allOperations.length.toString(),
+      )} GraphQL operations.`,
+    );
+  }
 
   const tsFiles = findFilesWithExtension(
     config.srcDir,
     ['.ts', '.tsx', '.js', '.jsx'],
     excludedFolders,
   );
-  console.log(`Found ${kleur.yellow(tsFiles.length.toString())} source files.`);
+  if (!json) {
+    console.log(
+      `Found ${kleur.yellow(tsFiles.length.toString())} source files.`,
+    );
+  }
 
   // Read every source file once, then test all operations against the cache
   // instead of re-reading each file for every operation.
@@ -203,6 +246,20 @@ export function mainFunction() {
     fileContents,
     fragmentUsagePatterns,
   );
+
+  if (json) {
+    console.log(
+      JSON.stringify(
+        buildJsonReport(unusedOperations, unusedFragments),
+        null,
+        2,
+      ),
+    );
+    if (unusedOperations.length > 0 || unusedFragments.length > 0) {
+      process.exit(1);
+    }
+    return;
+  }
 
   if (unusedOperations.length === 0 && unusedFragments.length === 0) {
     console.log(

--- a/src/core/gqlPruner.ts
+++ b/src/core/gqlPruner.ts
@@ -255,8 +255,9 @@ export function mainFunction(options: { json?: boolean } = {}) {
         2,
       ),
     );
+    // Use exitCode (not process.exit) so the piped JSON fully flushes first.
     if (unusedOperations.length > 0 || unusedFragments.length > 0) {
-      process.exit(1);
+      process.exitCode = 1;
     }
     return;
   }
@@ -275,5 +276,6 @@ export function mainFunction(options: { json?: boolean } = {}) {
     reportUnusedFragments(unusedFragments);
   }
 
-  process.exit(1);
+  // Use exitCode (not process.exit) so all report output flushes before exit.
+  process.exitCode = 1;
 }

--- a/src/types/FragmentInfo.d.ts
+++ b/src/types/FragmentInfo.d.ts
@@ -1,4 +1,6 @@
 export type FragmentInfo = {
   name: string;
   filePath: string;
+  /** 1-based line of the fragment definition within its source file. */
+  line?: number;
 };

--- a/src/types/OperationInfo.d.ts
+++ b/src/types/OperationInfo.d.ts
@@ -2,4 +2,6 @@ export type OperationInfo = {
   name: string;
   type: 'query' | 'mutation' | 'subscription';
   filePath: string;
+  /** 1-based line of the operation definition within its source file. */
+  line?: number;
 };

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -1,0 +1,18 @@
+export type CliOptions = {
+  command?: string;
+  json: boolean;
+};
+
+/**
+ * Parses CLI arguments (everything after the node binary and script path).
+ * Recognizes the optional `init` command and the `--json` flag, in any order.
+ *
+ * @param {string[]} argv - Arguments, e.g. `process.argv.slice(2)`.
+ * @returns {CliOptions} - The resolved command and flags.
+ */
+export function parseArgs(argv: string[]): CliOptions {
+  return {
+    command: argv.find((arg) => !arg.startsWith('-')),
+    json: argv.includes('--json'),
+  };
+}

--- a/src/utils/operations.ts
+++ b/src/utils/operations.ts
@@ -52,13 +52,18 @@ export function extractGraphqlEntities(filePath: string): GraphqlFileEntities {
             name: definition.name.value,
             type: definition.operation,
             filePath,
+            line: definition.loc?.startToken.line,
           });
         }
         // Spreads from every operation (named or anonymous) keep their
         // fragments alive, so they all count as reachability roots.
         getFragmentSpreads(definition).forEach((s) => operationSpreads.add(s));
       } else if (definition.kind === 'FragmentDefinition') {
-        fragments.push({ name: definition.name.value, filePath });
+        fragments.push({
+          name: definition.name.value,
+          filePath,
+          line: definition.loc?.startToken.line,
+        });
         fragmentSpreads.push({
           name: definition.name.value,
           spreads: getFragmentSpreads(definition),

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -1,0 +1,26 @@
+import { parseArgs } from '../src/utils/args';
+
+describe('parseArgs', () => {
+  it('defaults to no command and json=false', () => {
+    expect(parseArgs([])).toEqual({ command: undefined, json: false });
+  });
+
+  it('parses the init command', () => {
+    expect(parseArgs(['init'])).toEqual({ command: 'init', json: false });
+  });
+
+  it('parses the --json flag', () => {
+    expect(parseArgs(['--json'])).toEqual({ command: undefined, json: true });
+  });
+
+  it('parses a command together with --json (any order)', () => {
+    expect(parseArgs(['init', '--json'])).toEqual({
+      command: 'init',
+      json: true,
+    });
+    expect(parseArgs(['--json', 'init'])).toEqual({
+      command: 'init',
+      json: true,
+    });
+  });
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -38,9 +38,15 @@ describe('cli dispatch', () => {
     expect(mainFunction).not.toHaveBeenCalled();
   });
 
-  it('runs the pruner by default', () => {
+  it('runs the pruner by default (json=false)', () => {
     const { generateConfig, mainFunction } = runCli([]);
-    expect(mainFunction).toHaveBeenCalledTimes(1);
+    expect(mainFunction).toHaveBeenCalledWith({ json: false });
+    expect(generateConfig).not.toHaveBeenCalled();
+  });
+
+  it('passes --json through to the pruner', () => {
+    const { generateConfig, mainFunction } = runCli(['--json']);
+    expect(mainFunction).toHaveBeenCalledWith({ json: true });
     expect(generateConfig).not.toHaveBeenCalled();
   });
 });

--- a/test/gqlPruner.test.ts
+++ b/test/gqlPruner.test.ts
@@ -3,6 +3,7 @@ import * as fileUtils from '../src/utils/fileUtils';
 import { extractOperations } from '../src/utils/operations';
 import * as fragments from '../src/utils/fragments';
 import {
+  buildJsonReport,
   DEFAULT_EXCLUDED_FOLDERS,
   findUnusedOperations,
   mainFunction,
@@ -160,6 +161,31 @@ describe('gqlPruner', () => {
     });
   });
 
+  describe('buildJsonReport', () => {
+    it('serializes unused operations and fragments with a summary', () => {
+      expect(
+        buildJsonReport(
+          [{ name: 'A', type: 'query', filePath: 'a.gql', line: 3 }],
+          [{ name: 'F', filePath: 'b.gql', line: 7 }],
+        ),
+      ).toEqual({
+        unusedOperations: [
+          { name: 'A', type: 'query', file: 'a.gql', line: 3 },
+        ],
+        unusedFragments: [{ name: 'F', file: 'b.gql', line: 7 }],
+        summary: { unusedOperations: 1, unusedFragments: 1 },
+      });
+    });
+
+    it('produces empty arrays and a zeroed summary when nothing is unused', () => {
+      expect(buildJsonReport([], [])).toEqual({
+        unusedOperations: [],
+        unusedFragments: [],
+        summary: { unusedOperations: 0, unusedFragments: 0 },
+      });
+    });
+  });
+
   describe('mainFunction', () => {
     let exitSpy: jest.SpyInstance;
     let logSpy: jest.SpyInstance;
@@ -281,6 +307,61 @@ describe('gqlPruner', () => {
         ['source'],
         ['{Name}FragmentDoc'],
       );
+    });
+
+    it('outputs a JSON report and suppresses info logs in --json mode', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        'graphqlDir: ./g\nsrcDir: ./s\n',
+      );
+      mockedDirExists.mockReturnValue(true);
+      mockedFind
+        .mockReturnValueOnce(['a.gql'])
+        .mockReturnValueOnce(['App.tsx']);
+      mockedExtract.mockReturnValue([
+        { name: 'GetUser', type: 'query', filePath: 'a.gql', line: 1 },
+        { name: 'Unused', type: 'query', filePath: 'a.gql', line: 2 },
+      ]);
+      mockedRead.mockReturnValue(['useGetUserQuery()']);
+      mockedUnusedFragments.mockReturnValueOnce([
+        { name: 'DeadFrag', filePath: 'a.gql', line: 5 },
+      ]);
+
+      expect(() => mainFunction({ json: true })).toThrow('process.exit:1');
+      const out = logged();
+      expect(out).not.toContain('Found ');
+      const report = JSON.parse(out);
+      expect(report.unusedOperations).toEqual([
+        { name: 'Unused', type: 'query', file: 'a.gql', line: 2 },
+      ]);
+      expect(report.unusedFragments).toEqual([
+        { name: 'DeadFrag', file: 'a.gql', line: 5 },
+      ]);
+      expect(report.summary).toEqual({
+        unusedOperations: 1,
+        unusedFragments: 1,
+      });
+    });
+
+    it('emits an empty JSON report and exits 0 when nothing is unused (--json)', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        'graphqlDir: ./g\nsrcDir: ./s\n',
+      );
+      mockedDirExists.mockReturnValue(true);
+      mockedFind
+        .mockReturnValueOnce(['a.gql'])
+        .mockReturnValueOnce(['App.tsx']);
+      mockedExtract.mockReturnValue([
+        { name: 'GetUser', type: 'query', filePath: 'a.gql', line: 1 },
+      ]);
+      mockedRead.mockReturnValue(['useGetUserQuery()']);
+
+      expect(() => mainFunction({ json: true })).not.toThrow();
+      expect(exitSpy).not.toHaveBeenCalled();
+      const report = JSON.parse(logged());
+      expect(report.summary).toEqual({
+        unusedOperations: 0,
+        unusedFragments: 0,
+      });
     });
   });
 });

--- a/test/gqlPruner.test.ts
+++ b/test/gqlPruner.test.ts
@@ -207,6 +207,7 @@ describe('gqlPruner', () => {
       exitSpy.mockRestore();
       logSpy.mockRestore();
       errorSpy.mockRestore();
+      process.exitCode = 0; // report paths set exitCode; don't leak to the runner
     });
 
     it('exits 1 when the config file cannot be read', () => {
@@ -248,7 +249,8 @@ describe('gqlPruner', () => {
       ]);
       mockedRead.mockReturnValue(['const r = useGetUserQuery()']);
 
-      expect(() => mainFunction()).toThrow('process.exit:1');
+      mainFunction();
+      expect(process.exitCode).toBe(1);
       expect(logged()).toContain('Unused');
       expect(logged()).toContain('unused GraphQL operations');
     });
@@ -285,7 +287,8 @@ describe('gqlPruner', () => {
         { name: 'DeadFragment', filePath: 'a.gql' },
       ]);
 
-      expect(() => mainFunction()).toThrow('process.exit:1');
+      mainFunction();
+      expect(process.exitCode).toBe(1);
       expect(logged()).toContain('DeadFragment');
       expect(logged()).toContain('unused GraphQL fragments');
     });
@@ -326,7 +329,8 @@ describe('gqlPruner', () => {
         { name: 'DeadFrag', filePath: 'a.gql', line: 5 },
       ]);
 
-      expect(() => mainFunction({ json: true })).toThrow('process.exit:1');
+      mainFunction({ json: true });
+      expect(process.exitCode).toBe(1);
       const out = logged();
       expect(out).not.toContain('Found ');
       const report = JSON.parse(out);

--- a/test/operations.test.ts
+++ b/test/operations.test.ts
@@ -27,12 +27,9 @@ describe('operationUtils', () => {
 
   describe('extractOperations', () => {
     it('should extract operations from a valid GraphQL file', () => {
-      const mockContent = `
-        query MyQuery {
-          someField
-        }
-      `;
-      (fs.readFileSync as jest.Mock).mockReturnValue(mockContent);
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        'query MyQuery { someField }',
+      );
 
       const operations = extractOperations('./mockFile.gql');
       expect(operations).toEqual([
@@ -40,6 +37,7 @@ describe('operationUtils', () => {
           name: 'MyQuery',
           type: 'query',
           filePath: './mockFile.gql',
+          line: 1,
         },
       ]);
     });
@@ -87,11 +85,11 @@ describe('operationUtils', () => {
       );
       const r = extractGraphqlEntities('f.gql');
       expect(r.operations).toEqual([
-        { name: 'GetUser', type: 'query', filePath: 'f.gql' },
+        { name: 'GetUser', type: 'query', filePath: 'f.gql', line: 1 },
       ]);
-      expect(r.fragments.map((f) => f.name).sort()).toEqual([
-        'Inner',
-        'UserFields',
+      expect(r.fragments).toEqual([
+        { name: 'UserFields', filePath: 'f.gql', line: 2 },
+        { name: 'Inner', filePath: 'f.gql', line: 3 },
       ]);
       expect(r.operationSpreads).toEqual(['UserFields']);
       expect(r.fragmentSpreads).toEqual(


### PR DESCRIPTION
Implements **#32** — structured `--json` output and definition line numbers (the foundation for CI annotations, #33). Modeled on react.doctor's report UX.

## What it does
- **Line numbers:** each operation/fragment now carries its definition line (from the GraphQL AST `loc`).
- **`--json` flag:** emits `{ unusedOperations: [{name,type,file,line}], unusedFragments: [{name,file,line}], summary }` to stdout. In JSON mode the human-readable tables and the "Found N …" info logs are suppressed, so **stdout is pure, parseable JSON** — pipes straight into `jq` and CI.
- Exit codes unchanged (0 clean / 1 unused).

```bash
npx gqlprune --json | jq '.summary'
```

## Changes
- New `src/utils/args.ts` (`parseArgs`) wired into `cli.ts`.
- `buildJsonReport` in `gqlPruner`; optional `line` on `OperationInfo`/`FragmentInfo`; extraction populates it.
- README documents `--json`.

## Quality (TDD)
- Tests **73 → 82** (parseArgs, line extraction, `buildJsonReport`, and `--json` mainFunction paths incl. pure-JSON stdout assertion + exit codes); ~98% stmts / 100% funcs, coverage gate passing.
- Verified end-to-end: `--json` against a multi-file fixture emits valid JSON with correct ops/fragments, line numbers, and exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--json` option for machine-readable output, including unused operations, unused fragments, and summary counts.
  * Updated CLI argument parsing to recognize `--json` and support the `init` command with the flag in any order.
* **Bug Fixes**
  * Reported unused items now include source line numbers when available.
  * JSON mode suppresses human-readable logs; exit code behavior is preserved for scripting.
* **Documentation**
  * README now documents the `--json` output format and provides piping guidance (e.g., with `jq`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->