### PR TITLE
feat(cli): run without a config file via CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,24 @@ fragmentUsagePatterns:
 - `usagePatterns` _(optional)_: templates used to detect operation usage. Defaults to the table above when omitted.
 - `fragmentUsagePatterns` _(optional)_: templates for detecting fragments referenced directly in source (fragment masking). Defaults to `{Name}FragmentDoc`.
 
+### Without a config file (CLI flags)
+
+Every config field has a matching flag, so you can run gqlPrune with **no `gqlPrune.config.yaml`** — handy for a one-off `npx` try with zero setup:
+
+```bash
+npx gqlprune --graphql ./graphql --src ./src --ignore __generated__
+```
+
+| Flag | Config field |
+| ---- | ------------ |
+| `--graphql <dir>` | `graphqlDir` |
+| `--src <dir>` | `srcDir` |
+| `--ignore <folder>` _(repeatable)_ | `excludedFolders` |
+| `--pattern <template>` _(repeatable)_ | `usagePatterns` |
+| `--fragment-pattern <template>` _(repeatable)_ | `fragmentUsagePatterns` |
+
+Both `--flag value` and `--flag=value` work, in any order. **Precedence:** a flag overrides the same field in the YAML; flags alone work with no YAML; YAML alone works exactly as before. A list flag (e.g. `--ignore`) _replaces_ that list from the YAML rather than appending to it.
+
 ## Usage
 
 ```bash

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import { generateConfig } from './core/configGenerator.js';
 import { mainFunction } from './core/gqlPruner.js';
 import { parseArgs } from './utils/args.js';
 
-const { command, json, annotate } = parseArgs(process.argv.slice(2));
+const { command, json, annotate, config } = parseArgs(process.argv.slice(2));
 
 switch (command) {
   case 'init':
@@ -13,6 +13,7 @@ switch (command) {
     mainFunction({
       json,
       annotate: annotate || process.env.GITHUB_ACTIONS === 'true',
+      config,
     });
     break;
 }

--- a/src/core/gqlPruner.ts
+++ b/src/core/gqlPruner.ts
@@ -4,7 +4,7 @@ import * as yaml from 'js-yaml';
 import path from 'path';
 import { OperationInfo } from '../types/OperationInfo.js';
 import { FragmentInfo } from '../types/FragmentInfo.js';
-import { GqlPruneConfig } from '../types/GqlPruneConfig.js';
+import { CliConfig, GqlPruneConfig } from '../types/GqlPruneConfig.js';
 import {
   directoryExists,
   findFilesWithExtension,
@@ -19,7 +19,6 @@ import {
 } from '../utils/usagePatterns.js';
 import { extractOperations } from '../utils/operations.js';
 import { findUnusedFragmentsInCorpus } from '../utils/fragments.js';
-import { CliConfig } from '../utils/args.js';
 
 // Folders that are always excluded from traversal, regardless of config.
 export const DEFAULT_EXCLUDED_FOLDERS = ['node_modules', '.git'];
@@ -371,7 +370,9 @@ export function formatGeneratedFileWarnings(
  * fine — the CLI flags may supply everything. Throws on a malformed or
  * otherwise unreadable file so the problem isn't silently ignored.
  */
-export function resolveConfig(cliConfig: CliConfig = {}): GqlPruneConfig {
+export function resolveConfig(
+  cliConfig: CliConfig = {},
+): Partial<GqlPruneConfig> {
   let fileConfig: Partial<GqlPruneConfig> = {};
   let raw: string | undefined;
   try {
@@ -387,8 +388,8 @@ export function resolveConfig(cliConfig: CliConfig = {}): GqlPruneConfig {
   if (raw !== undefined && raw.trim() !== '') {
     fileConfig = (yaml.load(raw) as GqlPruneConfig) ?? {};
   }
-  // Required fields may still be absent here; mainFunction validates presence.
-  return { ...fileConfig, ...cliConfig } as GqlPruneConfig;
+  // Required fields may still be absent; mainFunction validates and narrows.
+  return { ...fileConfig, ...cliConfig };
 }
 
 export function mainFunction(
@@ -397,16 +398,16 @@ export function mainFunction(
   const json = options.json ?? false;
   const annotate = options.annotate ?? false;
 
-  let config: GqlPruneConfig;
+  let resolved: Partial<GqlPruneConfig>;
   try {
-    config = resolveConfig(options.config);
+    resolved = resolveConfig(options.config);
   } catch (e) {
     console.error(kleur.red('Error reading gqlPrune.config.yaml.'));
     console.error(e);
     process.exit(1);
   }
 
-  if (!config.graphqlDir || !config.srcDir) {
+  if (!resolved.graphqlDir || !resolved.srcDir) {
     console.error(
       kleur.red(
         'No configuration found. Create gqlPrune.config.yaml (run "gqlprune init") or pass --graphql <dir> and --src <dir>.',
@@ -414,6 +415,13 @@ export function mainFunction(
     );
     process.exit(1);
   }
+
+  // Required fields are present from here; widen to the full config type.
+  const config: GqlPruneConfig = {
+    ...resolved,
+    graphqlDir: resolved.graphqlDir,
+    srcDir: resolved.srcDir,
+  };
 
   if (!directoryExists(config.graphqlDir)) {
     console.error(

--- a/src/core/gqlPruner.ts
+++ b/src/core/gqlPruner.ts
@@ -19,6 +19,7 @@ import {
 } from '../utils/usagePatterns.js';
 import { extractOperations } from '../utils/operations.js';
 import { findUnusedFragmentsInCorpus } from '../utils/fragments.js';
+import { CliConfig } from '../utils/args.js';
 
 // Folders that are always excluded from traversal, regardless of config.
 export const DEFAULT_EXCLUDED_FOLDERS = ['node_modules', '.git'];
@@ -364,36 +365,66 @@ export function formatGeneratedFileWarnings(
   });
 }
 
+/**
+ * Loads configuration from `gqlPrune.config.yaml` (if present) and overlays the
+ * values provided as CLI flags, which win per field. A missing config file is
+ * fine — the CLI flags may supply everything. Throws on a malformed or
+ * otherwise unreadable file so the problem isn't silently ignored.
+ */
+export function resolveConfig(cliConfig: CliConfig = {}): GqlPruneConfig {
+  let fileConfig: Partial<GqlPruneConfig> = {};
+  let raw: string | undefined;
+  try {
+    raw = fs.readFileSync('./gqlPrune.config.yaml', 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error; // permissions or similar — surface it rather than hide it
+    }
+    // No config file: rely entirely on CLI flags.
+  }
+  // An empty/whitespace-only file is treated as no config (parsing it throws),
+  // so CLI flags alone can still drive the run.
+  if (raw !== undefined && raw.trim() !== '') {
+    fileConfig = (yaml.load(raw) as GqlPruneConfig) ?? {};
+  }
+  // Required fields may still be absent here; mainFunction validates presence.
+  return { ...fileConfig, ...cliConfig } as GqlPruneConfig;
+}
+
 export function mainFunction(
-  options: { json?: boolean; annotate?: boolean } = {},
+  options: { json?: boolean; annotate?: boolean; config?: CliConfig } = {},
 ) {
   const json = options.json ?? false;
   const annotate = options.annotate ?? false;
-  let config: GqlPruneConfig;
 
+  let config: GqlPruneConfig;
   try {
-    const configFile = fs.readFileSync('./gqlPrune.config.yaml', 'utf8');
-    config = yaml.load(configFile) as GqlPruneConfig;
+    config = resolveConfig(options.config);
   } catch (e) {
-    console.error(
-      kleur.red(
-        'Error reading the config file (gqlPrune.config.yaml). Run "gqlPrune init" to create one.',
-      ),
-    );
+    console.error(kleur.red('Error reading gqlPrune.config.yaml.'));
     console.error(e);
     process.exit(1);
   }
 
-  if (!config || !directoryExists(config.graphqlDir || '')) {
+  if (!config.graphqlDir || !config.srcDir) {
     console.error(
       kleur.red(
-        `Provided GraphQL directory "${config?.graphqlDir}" does not exist.`,
+        'No configuration found. Create gqlPrune.config.yaml (run "gqlprune init") or pass --graphql <dir> and --src <dir>.',
       ),
     );
     process.exit(1);
   }
 
-  if (!directoryExists(config.srcDir || '')) {
+  if (!directoryExists(config.graphqlDir)) {
+    console.error(
+      kleur.red(
+        `Provided GraphQL directory "${config.graphqlDir}" does not exist.`,
+      ),
+    );
+    process.exit(1);
+  }
+
+  if (!directoryExists(config.srcDir)) {
     console.error(
       kleur.red(`Provided source directory "${config.srcDir}" does not exist.`),
     );

--- a/src/types/GqlPruneConfig.d.ts
+++ b/src/types/GqlPruneConfig.d.ts
@@ -22,3 +22,15 @@ export interface GqlPruneConfig {
    */
   fragmentUsagePatterns?: string[];
 }
+
+/**
+ * Configuration that can be supplied as CLI flags instead of (or on top of)
+ * `gqlPrune.config.yaml`. The list fields come from repeatable flags and
+ * replace — rather than merge with — their YAML counterparts.
+ */
+export type CliConfig = Partial<
+  Pick<
+    GqlPruneConfig,
+    'graphqlDir' | 'srcDir' | 'usagePatterns' | 'fragmentUsagePatterns'
+  >
+> & { excludedFolders?: string[] };

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -1,15 +1,4 @@
-import { GqlPruneConfig } from '../types/GqlPruneConfig.js';
-
-/**
- * Configuration that can be supplied as CLI flags instead of (or on top of)
- * `gqlPrune.config.yaml`. The list fields come from repeatable flags.
- */
-export type CliConfig = Partial<
-  Pick<
-    GqlPruneConfig,
-    'graphqlDir' | 'srcDir' | 'usagePatterns' | 'fragmentUsagePatterns'
-  >
-> & { excludedFolders?: string[] };
+import { CliConfig } from '../types/GqlPruneConfig.js';
 
 export type CliOptions = {
   command?: string;

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -1,21 +1,112 @@
+import { GqlPruneConfig } from '../types/GqlPruneConfig.js';
+
+/**
+ * Configuration that can be supplied as CLI flags instead of (or on top of)
+ * `gqlPrune.config.yaml`. The list fields come from repeatable flags.
+ */
+export type CliConfig = Partial<
+  Pick<
+    GqlPruneConfig,
+    'graphqlDir' | 'srcDir' | 'usagePatterns' | 'fragmentUsagePatterns'
+  >
+> & { excludedFolders?: string[] };
+
 export type CliOptions = {
   command?: string;
   json: boolean;
   annotate: boolean;
+  config: CliConfig;
 };
 
 /**
  * Parses CLI arguments (everything after the node binary and script path).
- * Recognizes the optional `init` command and the `--json` / `--annotate` flags,
- * in any order.
+ *
+ * Recognizes the optional `init` command, the boolean `--json` / `--annotate`
+ * flags, and value flags that mirror the config file: `--graphql`, `--src`,
+ * and the repeatable `--ignore`, `--pattern`, `--fragment-pattern`. Value flags
+ * accept both `--flag value` and `--flag=value`, in any order. A value is never
+ * mistaken for the positional command.
  *
  * @param {string[]} argv - Arguments, e.g. `process.argv.slice(2)`.
- * @returns {CliOptions} - The resolved command and flags.
+ * @returns {CliOptions} - The resolved command, flags, and CLI config overrides.
  */
 export function parseArgs(argv: string[]): CliOptions {
-  return {
-    command: argv.find((arg) => !arg.startsWith('-')),
-    json: argv.includes('--json'),
-    annotate: argv.includes('--annotate'),
-  };
+  const config: CliConfig = {};
+  const excludedFolders: string[] = [];
+  const usagePatterns: string[] = [];
+  const fragmentUsagePatterns: string[] = [];
+  let command: string | undefined;
+  let json = false;
+  let annotate = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    // Support `--flag=value` alongside `--flag value`.
+    let name = arg;
+    let inlineValue: string | undefined;
+    if (arg.startsWith('--')) {
+      const eq = arg.indexOf('=');
+      if (eq !== -1) {
+        name = arg.slice(0, eq);
+        inlineValue = arg.slice(eq + 1);
+      }
+    }
+
+    // The flag's value: the inline `=value`, else the next arg when it isn't
+    // itself a flag (so a value is never consumed as the command).
+    const takeValue = (): string | undefined => {
+      if (inlineValue !== undefined) return inlineValue;
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith('-')) {
+        i += 1;
+        return next;
+      }
+      return undefined;
+    };
+
+    switch (name) {
+      case '--json':
+        json = true;
+        break;
+      case '--annotate':
+        annotate = true;
+        break;
+      case '--graphql': {
+        const value = takeValue();
+        if (value !== undefined) config.graphqlDir = value;
+        break;
+      }
+      case '--src': {
+        const value = takeValue();
+        if (value !== undefined) config.srcDir = value;
+        break;
+      }
+      case '--ignore': {
+        const value = takeValue();
+        if (value !== undefined) excludedFolders.push(value);
+        break;
+      }
+      case '--pattern': {
+        const value = takeValue();
+        if (value !== undefined) usagePatterns.push(value);
+        break;
+      }
+      case '--fragment-pattern': {
+        const value = takeValue();
+        if (value !== undefined) fragmentUsagePatterns.push(value);
+        break;
+      }
+      default:
+        if (!arg.startsWith('-') && command === undefined) command = arg;
+    }
+  }
+
+  if (excludedFolders.length > 0) config.excludedFolders = excludedFolders;
+  if (usagePatterns.length > 0) config.usagePatterns = usagePatterns;
+  if (fragmentUsagePatterns.length > 0) {
+    config.fragmentUsagePatterns = fragmentUsagePatterns;
+  }
+
+  return { command, json, annotate, config };
 }

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -1,11 +1,12 @@
 import { parseArgs } from '../src/utils/args';
 
 describe('parseArgs', () => {
-  it('defaults to no command, json=false, annotate=false', () => {
+  it('defaults to no command, json=false, annotate=false, empty config', () => {
     expect(parseArgs([])).toEqual({
       command: undefined,
       json: false,
       annotate: false,
+      config: {},
     });
   });
 
@@ -14,6 +15,7 @@ describe('parseArgs', () => {
       command: 'init',
       json: false,
       annotate: false,
+      config: {},
     });
   });
 
@@ -22,6 +24,7 @@ describe('parseArgs', () => {
       command: undefined,
       json: true,
       annotate: false,
+      config: {},
     });
   });
 
@@ -30,6 +33,7 @@ describe('parseArgs', () => {
       command: undefined,
       json: false,
       annotate: true,
+      config: {},
     });
   });
 
@@ -38,6 +42,71 @@ describe('parseArgs', () => {
       command: 'init',
       json: true,
       annotate: true,
+      config: {},
     });
+  });
+
+  it('parses --graphql and --src as config paths', () => {
+    expect(
+      parseArgs(['--graphql', './graphql', '--src', './src']).config,
+    ).toEqual({ graphqlDir: './graphql', srcDir: './src' });
+  });
+
+  it('does not mistake a flag value for the command', () => {
+    // './graphql' is the value of --graphql, not a positional command.
+    expect(parseArgs(['--graphql', './graphql']).command).toBeUndefined();
+  });
+
+  it('supports the --flag=value form', () => {
+    expect(parseArgs(['--graphql=./g', '--src=./s']).config).toEqual({
+      graphqlDir: './g',
+      srcDir: './s',
+    });
+  });
+
+  it('collects repeatable --ignore into excludedFolders', () => {
+    expect(
+      parseArgs(['--ignore', '__generated__', '--ignore', 'dist']).config,
+    ).toEqual({ excludedFolders: ['__generated__', 'dist'] });
+  });
+
+  it('collects repeatable --pattern and --fragment-pattern', () => {
+    expect(
+      parseArgs([
+        '--pattern',
+        'use{Name}{Type}',
+        '--fragment-pattern',
+        '{Name}FragmentDoc',
+      ]).config,
+    ).toEqual({
+      usagePatterns: ['use{Name}{Type}'],
+      fragmentUsagePatterns: ['{Name}FragmentDoc'],
+    });
+  });
+
+  it('combines a command, boolean flags and config flags', () => {
+    expect(
+      parseArgs([
+        '--json',
+        '--graphql',
+        './g',
+        '--src',
+        './s',
+        '--ignore',
+        'x',
+      ]),
+    ).toEqual({
+      command: undefined,
+      json: true,
+      annotate: false,
+      config: { graphqlDir: './g', srcDir: './s', excludedFolders: ['x'] },
+    });
+  });
+
+  it('ignores a value flag given no value', () => {
+    // `--graphql` with no following value (the next token is another flag).
+    const result = parseArgs(['--graphql', '--json']);
+    expect(result.config).toEqual({});
+    expect(result.json).toBe(true);
   });
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -47,22 +47,47 @@ describe('cli dispatch', () => {
 
   it('runs the pruner by default', () => {
     const { generateConfig, mainFunction } = runCli([]);
-    expect(mainFunction).toHaveBeenCalledWith({ json: false, annotate: false });
+    expect(mainFunction).toHaveBeenCalledWith({
+      json: false,
+      annotate: false,
+      config: {},
+    });
     expect(generateConfig).not.toHaveBeenCalled();
   });
 
   it('passes --json through to the pruner', () => {
     const { mainFunction } = runCli(['--json']);
-    expect(mainFunction).toHaveBeenCalledWith({ json: true, annotate: false });
+    expect(mainFunction).toHaveBeenCalledWith({
+      json: true,
+      annotate: false,
+      config: {},
+    });
   });
 
   it('passes --annotate through to the pruner', () => {
     const { mainFunction } = runCli(['--annotate']);
-    expect(mainFunction).toHaveBeenCalledWith({ json: false, annotate: true });
+    expect(mainFunction).toHaveBeenCalledWith({
+      json: false,
+      annotate: true,
+      config: {},
+    });
   });
 
   it('auto-enables annotations under GitHub Actions', () => {
     const { mainFunction } = runCli([], { GITHUB_ACTIONS: 'true' });
-    expect(mainFunction).toHaveBeenCalledWith({ json: false, annotate: true });
+    expect(mainFunction).toHaveBeenCalledWith({
+      json: false,
+      annotate: true,
+      config: {},
+    });
+  });
+
+  it('passes config flags through to the pruner', () => {
+    const { mainFunction } = runCli(['--graphql', './g', '--src', './s']);
+    expect(mainFunction).toHaveBeenCalledWith({
+      json: false,
+      annotate: false,
+      config: { graphqlDir: './g', srcDir: './s' },
+    });
   });
 });

--- a/test/gqlPruner.test.ts
+++ b/test/gqlPruner.test.ts
@@ -10,6 +10,7 @@ import {
   formatAnnotations,
   formatGeneratedFileWarnings,
   mainFunction,
+  resolveConfig,
   resolveExcludedFolders,
   resolveFragmentUsagePatterns,
   resolveUsagePatterns,
@@ -383,6 +384,61 @@ describe('gqlPruner', () => {
     });
   });
 
+  describe('resolveConfig', () => {
+    const enoent = () => {
+      const err = new Error('missing') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    };
+
+    it('reads the YAML file when present', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        'graphqlDir: ./g\nsrcDir: ./s\n',
+      );
+      expect(resolveConfig()).toEqual({ graphqlDir: './g', srcDir: './s' });
+    });
+
+    it('treats an empty config file as no config (CLI flags still apply)', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue('');
+      expect(resolveConfig({ graphqlDir: './g', srcDir: './s' })).toEqual({
+        graphqlDir: './g',
+        srcDir: './s',
+      });
+    });
+
+    it('uses CLI config alone when the file is missing (ENOENT)', () => {
+      (fs.readFileSync as jest.Mock).mockImplementation(enoent);
+      expect(resolveConfig({ graphqlDir: './g', srcDir: './s' })).toEqual({
+        graphqlDir: './g',
+        srcDir: './s',
+      });
+    });
+
+    it('lets CLI flags override YAML values per field', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        'graphqlDir: ./yaml-g\nsrcDir: ./yaml-s\n',
+      );
+      expect(resolveConfig({ srcDir: './cli-s' })).toEqual({
+        graphqlDir: './yaml-g',
+        srcDir: './cli-s',
+      });
+    });
+
+    it('throws on a malformed config file', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue('graphqlDir: [');
+      expect(() => resolveConfig()).toThrow();
+    });
+
+    it('rethrows a non-ENOENT read error', () => {
+      (fs.readFileSync as jest.Mock).mockImplementation(() => {
+        const err = new Error('eacces') as NodeJS.ErrnoException;
+        err.code = 'EACCES';
+        throw err;
+      });
+      expect(() => resolveConfig()).toThrow('eacces');
+    });
+  });
+
   describe('mainFunction', () => {
     let exitSpy: jest.SpyInstance;
     let logSpy: jest.SpyInstance;
@@ -659,6 +715,42 @@ describe('gqlPruner', () => {
       expect(errs).toContain('::warning::Suspected generated file');
       // The "%" in "100%" is escaped for the workflow command.
       expect(errs).toContain('100%25');
+    });
+
+    it('runs from CLI config when no config file exists', () => {
+      (fs.readFileSync as jest.Mock).mockImplementation(() => {
+        const err = new Error('missing') as NodeJS.ErrnoException;
+        err.code = 'ENOENT';
+        throw err;
+      });
+      mockedDirExists.mockReturnValue(true);
+      mockedFind
+        .mockReturnValueOnce(['a.gql'])
+        .mockReturnValueOnce(['App.tsx']);
+      mockedExtract.mockReturnValue([
+        { name: 'GetUser', type: 'query', filePath: 'a.gql' },
+      ]);
+      mockedReadSources.mockReturnValue([
+        { file: 'App.tsx', content: 'useGetUserQuery()' },
+      ]);
+
+      expect(() =>
+        mainFunction({ config: { graphqlDir: './g', srcDir: './s' } }),
+      ).not.toThrow();
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(logged()).toContain('No unused');
+    });
+
+    it('exits 1 with guidance when neither a config file nor flags supply dirs', () => {
+      (fs.readFileSync as jest.Mock).mockImplementation(() => {
+        const err = new Error('missing') as NodeJS.ErrnoException;
+        err.code = 'ENOENT';
+        throw err;
+      });
+
+      expect(() => mainFunction()).toThrow('process.exit:1');
+      const errs = errorSpy.mock.calls.flat().join('\n');
+      expect(errs).toContain('--graphql');
     });
   });
 });

--- a/test/gqlPruner.test.ts
+++ b/test/gqlPruner.test.ts
@@ -424,6 +424,15 @@ describe('gqlPruner', () => {
       });
     });
 
+    it('replaces (not merges) a YAML list when a list flag is given', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        'excludedFolders:\n  - yaml-only\n',
+      );
+      expect(resolveConfig({ excludedFolders: ['cli-only'] })).toEqual({
+        excludedFolders: ['cli-only'],
+      });
+    });
+
     it('throws on a malformed config file', () => {
       (fs.readFileSync as jest.Mock).mockReturnValue('graphqlDir: [');
       expect(() => resolveConfig()).toThrow();


### PR DESCRIPTION
Closes #36.

## What
Run gqlPrune with **no `gqlPrune.config.yaml`** by passing config as flags — zero-config `npx` adoption:

```bash
npx gqlprune --graphql ./graphql --src ./src --ignore __generated__
```

| Flag | Config field |
| ---- | ------------ |
| `--graphql <dir>` | `graphqlDir` |
| `--src <dir>` | `srcDir` |
| `--ignore <folder>` _(repeatable)_ | `excludedFolders` |
| `--pattern <template>` _(repeatable)_ | `usagePatterns` |
| `--fragment-pattern <template>` _(repeatable)_ | `fragmentUsagePatterns` |

## How
- **`parseArgs`** is now a value-aware parser: supports `--flag value` and `--flag=value`, in any order, and never mistakes a flag's value for the positional command. Repeatable flags collect into lists. Returns a `CliConfig`.
- **`resolveConfig`** merges the YAML (now **optional**) with CLI overrides, which win per field. Tolerant of a missing file (`ENOENT`) and an empty file; **throws on a malformed file** (so a broken config isn't silently ignored).
- **`mainFunction`** validates `graphqlDir`/`srcDir` are present from *either* source and prints actionable guidance otherwise (`No configuration found … run "gqlprune init" or pass --graphql <dir> and --src <dir>`).

## Precedence (per the issue)
Flag overrides the same YAML field · flags-only works with no YAML · YAML-only works exactly as before. A list flag (e.g. `--ignore`) **replaces** the YAML list rather than appending.

## Testing
- TDD: parser + `resolveConfig` specs written first. Covers `--flag=value`, repeatable flags, value-not-mistaken-for-command, YAML-only / CLI-only / merge / malformed / empty-file.
- Verified end-to-end with no config file: flags run works; no-config-no-flags prints guidance; `--flag=value` + `--json` emits clean JSON.
- Full gate green (build, typecheck, lint, **121 tests**, coverage above thresholds).

## Docs
README: new "Without a config file (CLI flags)" section with the flag table and precedence rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run `gqlPrune` with CLI flags only (no `gqlPrune.config.yaml` required).
  * Added CLI support for setting `--graphql`, `--src`, plus repeatable ignore/pattern/fragment-pattern options.
* **Bug Fixes**
  * Improved behavior for missing or empty config files.
  * CLI options override config values; repeatable list flags replace (not append) list settings.
* **Documentation**
  * README now includes CLI-only examples, flag-to-setting mappings, and precedence rules.
* **Tests**
  * Expanded unit/integration coverage for argument parsing and config resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->