### PR TITLE
feat(cli): add --version / -v flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ This prints any unused GraphQL operations and fragments. The command exits with:
 - **0** when nothing unused is found (suitable for CI gates).
 - **1** when unused operations or fragments are found (or on configuration errors).
 
+Print the installed version with `gqlprune --version` (or `-v`).
+
 ### JSON output
 
 Pass `--json` for a machine-readable report (CI, dashboards, scripting) instead of the human-readable tables:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,9 +5,16 @@ import { parseArgs } from './utils/args.js';
 import { notifyUpdate } from './utils/updateNotifier.js';
 import { pkg } from './utils/pkgInfo.js';
 
-const { command, json, annotate, config } = parseArgs(process.argv.slice(2));
+const { command, json, annotate, version, config } = parseArgs(
+  process.argv.slice(2),
+);
 
 async function run(): Promise<void> {
+  if (version) {
+    console.log(pkg.version);
+    return;
+  }
+
   if (command === 'init') {
     await generateConfig();
   } else {

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -4,6 +4,7 @@ export type CliOptions = {
   command?: string;
   json: boolean;
   annotate: boolean;
+  version: boolean;
   config: CliConfig;
 };
 
@@ -27,6 +28,7 @@ export function parseArgs(argv: string[]): CliOptions {
   let command: string | undefined;
   let json = false;
   let annotate = false;
+  let version = false;
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -60,6 +62,10 @@ export function parseArgs(argv: string[]): CliOptions {
         break;
       case '--annotate':
         annotate = true;
+        break;
+      case '--version':
+      case '-v':
+        version = true;
         break;
       case '--graphql': {
         const value = takeValue();
@@ -97,5 +103,5 @@ export function parseArgs(argv: string[]): CliOptions {
     config.fragmentUsagePatterns = fragmentUsagePatterns;
   }
 
-  return { command, json, annotate, config };
+  return { command, json, annotate, version, config };
 }

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -1,11 +1,12 @@
 import { parseArgs } from '../src/utils/args';
 
 describe('parseArgs', () => {
-  it('defaults to no command, json=false, annotate=false, empty config', () => {
+  it('defaults to no command, all flags false, empty config', () => {
     expect(parseArgs([])).toEqual({
       command: undefined,
       json: false,
       annotate: false,
+      version: false,
       config: {},
     });
   });
@@ -15,6 +16,7 @@ describe('parseArgs', () => {
       command: 'init',
       json: false,
       annotate: false,
+      version: false,
       config: {},
     });
   });
@@ -24,6 +26,7 @@ describe('parseArgs', () => {
       command: undefined,
       json: true,
       annotate: false,
+      version: false,
       config: {},
     });
   });
@@ -33,8 +36,15 @@ describe('parseArgs', () => {
       command: undefined,
       json: false,
       annotate: true,
+      version: false,
       config: {},
     });
+  });
+
+  it('parses --version and the -v short flag', () => {
+    expect(parseArgs(['--version']).version).toBe(true);
+    expect(parseArgs(['-v']).version).toBe(true);
+    expect(parseArgs([]).version).toBe(false);
   });
 
   it('parses a command together with flags in any order', () => {
@@ -42,6 +52,7 @@ describe('parseArgs', () => {
       command: 'init',
       json: true,
       annotate: true,
+      version: false,
       config: {},
     });
   });
@@ -99,6 +110,7 @@ describe('parseArgs', () => {
       command: undefined,
       json: true,
       annotate: false,
+      version: false,
       config: { graphqlDir: './g', srcDir: './s', excludedFolders: ['x'] },
     });
   });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -59,6 +59,20 @@ describe('cli dispatch', () => {
     expect(mainFunction).not.toHaveBeenCalled();
   });
 
+  it('prints the version and exits on --version', () => {
+    const logSpy = jest
+      .spyOn(console, 'log')
+      .mockImplementation(() => undefined);
+    const { mainFunction, generateConfig, notifyUpdate } = runCli([
+      '--version',
+    ]);
+    expect(logSpy).toHaveBeenCalledWith('0.0.0-test');
+    expect(mainFunction).not.toHaveBeenCalled();
+    expect(generateConfig).not.toHaveBeenCalled();
+    expect(notifyUpdate).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+  });
+
   it('runs the pruner by default', () => {
     const { generateConfig, mainFunction } = runCli([]);
     expect(mainFunction).toHaveBeenCalledWith({


### PR DESCRIPTION
Closes #51.

## What
`gqlprune --version` (or `-v`) prints the installed version and exits:

```
$ gqlprune --version
2.7.0
```

## How
- `parseArgs` recognizes `--version` and `-v` (`version: boolean`).
- `cli.ts` prints `pkg.version` to **stdout** and returns **before** any scan / config / update-notifier logic, so it works with no config file.
- Reuses the existing `pkgInfo` shim (already reads `package.json` for the notifier) — **no new dependency**.

## Testing
- `parseArgs`: `--version` and `-v` set `version: true`; existing full-object assertions updated for the new field.
- `cli.test`: `--version` prints the version and does **not** invoke the scan, config generator, or update notifier.
- Verified e2e against the built CLI: `--version` and `-v` both print `2.7.0`.
- Full gate green (build, typecheck, lint, **157 tests**).

## Docs
README Usage note for `--version` / `-v`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--version`/`-v` command-line option to display the installed version and exit immediately.
  * Updated the CLI usage docs to include the new version flag.

* **Tests**
  * Expanded command-line parsing coverage for the new version flag.
  * Added a test to verify version output and confirm no other actions run when the flag is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->