### PR TITLE
feat(config): unified `exclude` with glob support (files + folders)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ A fragment spread only by another _unused_ fragment is reported too. Note: a fra
 
 Because usage is detected by string-matching `srcDir`, **GraphQL Code Generator output that lives inside `srcDir`** is a trap: a single generated file (e.g. `src/gql/graphql.ts`) references _every_ operation, so everything looks used and nothing is ever reported unused — silently.
 
-gqlPrune guards against this. When one source file alone references most of your operations, it prints a warning naming the file and pointing you at `excludedFolders`:
+gqlPrune guards against this. When one source file alone references most of your operations, it prints a warning naming the file and pointing you at `exclude`:
 
-> ⚠ Suspected generated file "src/gql/graphql.ts" references 100% of all operations (50/50) and looks generated — exclude it via "excludedFolders" in gqlPrune.config.yaml or unused results will be unreliable.
+> ⚠ Suspected generated file "src/gql/graphql.ts" references 100% of all operations (50/50) and looks generated — add it to "exclude" in gqlPrune.config.yaml or unused results will be unreliable.
 
-Add that file's folder to `excludedFolders` and re-run. The warning goes to **stderr** (so it also surfaces in `--json` mode) and is included in the JSON report's `warnings` array; it does not change the exit code.
+Add it to `exclude` (e.g. `'**/*.generated.ts'`) and re-run. The warning goes to **stderr** (so it also surfaces in `--json` mode) and is included in the JSON report's `warnings` array; it does not change the exit code.
 
 ## Setup
 
@@ -79,8 +79,10 @@ npx gqlprune init
 ```yaml
 graphqlDir: ./path/to/graphql
 srcDir: ./src
-excludedFolders:
-  - __generated__
+# Glob patterns (gitignore-flavored) for files/folders to skip.
+exclude:
+  - '**/__generated__'
+  - '**/*.generated.ts'
 # Optional — override how operation usage is detected.
 # Supports {name}, {Name}, {type}, {Type} placeholders.
 usagePatterns:
@@ -94,7 +96,8 @@ fragmentUsagePatterns:
 
 - `graphqlDir`: directory **— or an array of directories —** containing your `.gql`/`.graphql` files.
 - `srcDir`: directory **— or an array of directories —** containing your source files (`.ts`, `.tsx`, `.js`, `.jsx`).
-- `excludedFolders` _(optional)_: folder **names** (e.g. `__generated__`, matched anywhere in the tree) or **paths relative to the project root** (e.g. `src/legacy`). `node_modules` and `.git` are always excluded.
+- `exclude` _(optional)_: gitignore-flavored glob patterns for **files and folders** to skip. A name without a slash matches anywhere by basename (`__generated__`), a path with a slash is anchored to the project root (`src/legacy`), `**` matches any depth, `*.generated.ts` matches files, and a leading `!` re-includes. `node_modules` and `.git` are always excluded.
+- `excludedFolders` _(optional, **deprecated** — use `exclude`)_: folder names or root-relative paths. Still honored and merged into the same matcher.
 - `usagePatterns` _(optional)_: templates used to detect operation usage. Defaults to the table above when omitted.
 - `fragmentUsagePatterns` _(optional)_: templates for detecting fragments referenced directly in source (fragment masking). Defaults to `{Name}FragmentDoc`.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ fragmentUsagePatterns:
 
 - `graphqlDir`: directory **— or an array of directories —** containing your `.gql`/`.graphql` files.
 - `srcDir`: directory **— or an array of directories —** containing your source files (`.ts`, `.tsx`, `.js`, `.jsx`).
-- `exclude` _(optional)_: gitignore-flavored glob patterns for **files and folders** to skip. A name without a slash matches anywhere by basename (`__generated__`), a path with a slash is anchored to the project root (`src/legacy`), `**` matches any depth, `*.generated.ts` matches files, and a leading `!` re-includes. `node_modules` and `.git` are always excluded.
+- `exclude` _(optional)_: gitignore-flavored glob patterns for **files and folders** to skip. A name without a slash matches anywhere by basename (`__generated__`), a path with a slash is anchored to the project root (`src/legacy`), `**` matches any depth, `*.generated.ts` matches files, and a leading `!` re-includes. A `!` re-include always wins (order-independent), but — as in gitignore — it **can't** re-include a path whose parent directory is excluded (excluded directories aren't traversed). `node_modules` and `.git` are always excluded.
 - `excludedFolders` _(optional, **deprecated** — use `exclude`)_: folder names or root-relative paths. Still honored and merged into the same matcher.
 - `usagePatterns` _(optional)_: templates used to detect operation usage. Defaults to the table above when omitted.
 - `fragmentUsagePatterns` _(optional)_: templates for detecting fragments referenced directly in source (fragment masking). Defaults to `{Name}FragmentDoc`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,15 +12,17 @@
         "graphql": "^17.0.1",
         "inquirer": "^14.0.2",
         "js-yaml": "^5.1.0",
-        "kleur": "^4.1.5"
+        "kleur": "^4.1.5",
+        "picomatch": "^4.0.4"
       },
       "bin": {
-        "gqlPrune": "dist/cli.js"
+        "gqlprune": "dist/cli.js"
       },
       "devDependencies": {
         "@tsconfig/node20": "^20.1.9",
         "@types/jest": "^30.0.0",
         "@types/node": "^26.0.0",
+        "@types/picomatch": "^4.0.3",
         "eslint": "^10.5.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
@@ -533,35 +535,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1789,6 +1766,13 @@
         "undici-types": "~8.3.0"
       }
     },
+    "node_modules/@types/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -2334,6 +2318,40 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
@@ -5106,7 +5124,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -535,10 +534,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1761,7 +1783,6 @@
       "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1803,7 +1824,6 @@
       "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.62.0",
@@ -1843,7 +1863,6 @@
       "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.62.0",
         "@typescript-eslint/types": "8.62.0",
@@ -2320,40 +2339,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
@@ -2402,7 +2387,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2670,7 +2654,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -3099,7 +3082,6 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3159,7 +3141,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4008,7 +3989,6 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -5227,7 +5207,6 @@
       "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5979,7 +5958,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -50,12 +50,14 @@
     "graphql": "^17.0.1",
     "inquirer": "^14.0.2",
     "js-yaml": "^5.1.0",
-    "kleur": "^4.1.5"
+    "kleur": "^4.1.5",
+    "picomatch": "^4.0.4"
   },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.9",
     "@types/jest": "^30.0.0",
     "@types/node": "^26.0.0",
+    "@types/picomatch": "^4.0.3",
     "eslint": "^10.5.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",

--- a/src/core/configGenerator.ts
+++ b/src/core/configGenerator.ts
@@ -2,12 +2,16 @@ import inquirer from 'inquirer';
 import * as yaml from 'js-yaml';
 import fs from 'fs';
 import * as path from 'path';
-import { directoryExists, findFilesWithExtension } from '../utils/fileUtils.js';
+import {
+  createExcludeMatcher,
+  directoryExists,
+  findFilesWithExtension,
+} from '../utils/fileUtils.js';
 import { resolveDirs, scanProject } from './gqlPruner.js';
 import { GqlPruneConfig } from '../types/GqlPruneConfig.js';
 
 // Folders never worth scanning when auto-detecting the project layout.
-const DETECT_EXCLUDES = ['node_modules', '.git', 'dist'];
+const isDetectExcluded = createExcludeMatcher(['node_modules', '.git', 'dist']);
 
 /** Splits a comma-separated input into a trimmed list of folder names. */
 export function splitFolders(input: string): string[] {
@@ -43,7 +47,7 @@ function formatDir(dir: string): string {
 /** Suggests a `graphqlDir` from where the `.gql`/`.graphql` files live. */
 export function detectGraphqlDir(): string | undefined {
   const dir = commonParentDir(
-    findFilesWithExtension('.', ['.gql', '.graphql'], DETECT_EXCLUDES),
+    findFilesWithExtension('.', ['.gql', '.graphql'], isDetectExcluded),
   );
   return dir === undefined ? undefined : formatDir(dir);
 }
@@ -55,7 +59,7 @@ export function detectSrcDir(): string | undefined {
     findFilesWithExtension(
       '.',
       ['.ts', '.tsx', '.js', '.jsx'],
-      DETECT_EXCLUDES,
+      isDetectExcluded,
     ),
   );
   return dir === undefined ? undefined : formatDir(dir);

--- a/src/core/gqlPruner.ts
+++ b/src/core/gqlPruner.ts
@@ -6,6 +6,7 @@ import { OperationInfo } from '../types/OperationInfo.js';
 import { FragmentInfo } from '../types/FragmentInfo.js';
 import { CliConfig, GqlPruneConfig } from '../types/GqlPruneConfig.js';
 import {
+  createExcludeMatcher,
   directoryExists,
   findFilesWithExtension,
   isOperationUsedInContents,
@@ -24,17 +25,18 @@ import { findUnusedFragmentsInCorpus } from '../utils/fragments.js';
 export const DEFAULT_EXCLUDED_FOLDERS = ['node_modules', '.git'];
 
 /**
- * Normalizes `excludedFolders` (string | string[] | undefined) and adds the
- * folders that are always excluded (`node_modules`, `.git`).
+ * Collects every exclude pattern: the `exclude` globs, the deprecated
+ * `excludedFolders` (folded into the same matcher), and the always-excluded
+ * `node_modules` / `.git`.
  */
-export function resolveExcludedFolders(config: GqlPruneConfig): string[] {
-  let excludedFolders: string[] = [];
-  if (Array.isArray(config.excludedFolders)) {
-    excludedFolders = config.excludedFolders;
-  } else if (typeof config.excludedFolders === 'string') {
-    excludedFolders = [config.excludedFolders];
-  }
-  return [...new Set([...excludedFolders, ...DEFAULT_EXCLUDED_FOLDERS])];
+export function resolveExcludePatterns(config: GqlPruneConfig): string[] {
+  return [
+    ...new Set([
+      ...resolveDirs(config.exclude),
+      ...resolveDirs(config.excludedFolders),
+      ...DEFAULT_EXCLUDED_FOLDERS,
+    ]),
+  ];
 }
 
 /**
@@ -377,7 +379,7 @@ export function formatGeneratedFileWarnings(
     return (
       `Suspected generated file "${warning.file}" references ${percent}% of all ` +
       `operations (${warning.matchedOperations}/${warning.totalOperations})${generated} — ` +
-      `exclude it via "excludedFolders" in gqlPrune.config.yaml or unused results will be unreliable.`
+      `add it to "exclude" in gqlPrune.config.yaml or unused results will be unreliable.`
     );
   });
 }
@@ -426,7 +428,7 @@ export type ScanResult = {
  * `gqlprune init`'s preview, so the preview always reflects the real run.
  */
 export function scanProject(config: GqlPruneConfig): ScanResult {
-  const excludedFolders = resolveExcludedFolders(config);
+  const isExcluded = createExcludeMatcher(resolveExcludePatterns(config));
   const usagePatterns = resolveUsagePatterns(config);
   const fragmentUsagePatterns = resolveFragmentUsagePatterns(config);
 
@@ -434,7 +436,7 @@ export function scanProject(config: GqlPruneConfig): ScanResult {
   const gqlFiles = [
     ...new Set(
       resolveDirs(config.graphqlDir).flatMap((dir) =>
-        findFilesWithExtension(dir, ['.gql', '.graphql'], excludedFolders),
+        findFilesWithExtension(dir, ['.gql', '.graphql'], isExcluded),
       ),
     ),
   ];
@@ -443,11 +445,7 @@ export function scanProject(config: GqlPruneConfig): ScanResult {
   const tsFiles = [
     ...new Set(
       resolveDirs(config.srcDir).flatMap((dir) =>
-        findFilesWithExtension(
-          dir,
-          ['.ts', '.tsx', '.js', '.jsx'],
-          excludedFolders,
-        ),
+        findFilesWithExtension(dir, ['.ts', '.tsx', '.js', '.jsx'], isExcluded),
       ),
     ),
   ];

--- a/src/types/GqlPruneConfig.d.ts
+++ b/src/types/GqlPruneConfig.d.ts
@@ -4,9 +4,17 @@ export interface GqlPruneConfig {
   /** Directory (or directories) containing your source files. */
   srcDir: string | string[];
   /**
-   * Folder names (e.g. `__generated__`) or paths relative to the project root
-   * (e.g. `src/generated`) to exclude from traversal. `node_modules` and `.git`
-   * are always excluded.
+   * Glob patterns (gitignore-flavored) for files and folders to skip during
+   * traversal. A name without a slash matches anywhere by basename; a path with
+   * a slash is anchored to the project root; a leading `!` re-includes.
+   * Examples: `__generated__`, `*.generated.ts`, `src/legacy`, `!keep`.
+   * `node_modules` and `.git` are always excluded.
+   */
+  exclude?: string | string[];
+  /**
+   * @deprecated Use `exclude` instead. Folder names (e.g. `__generated__`) or
+   * paths relative to the project root (e.g. `src/generated`) to exclude. Still
+   * honored — merged into the same matcher as `exclude`.
    */
   excludedFolders?: string[] | string;
   /**

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -1,61 +1,56 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import picomatch from 'picomatch';
+
 const baseDir = path.resolve('./');
 
-/**
- * Normalizes a folder entry so it can be matched reliably across platforms:
- * converts backslashes to forward slashes (Windows `path.relative` output),
- * trims whitespace, and strips a leading `./` and any trailing slashes.
- */
-function normalizeFolder(folder: string): string {
-  return folder
-    .trim()
-    .replace(/\\/g, '/')
-    .replace(/^\.\//, '')
-    .replace(/\/+$/, '');
+/** Tests a project-root-relative path against the configured exclude patterns. */
+export type ExcludeMatcher = (relativePath: string) => boolean;
+
+/** The path of `itemPath` relative to the project root, as a posix string. */
+function toRelativePosix(itemPath: string): string {
+  return path.relative(baseDir, path.resolve(itemPath)).replace(/\\/g, '/');
 }
 
 /**
- * Determines whether a directory should be skipped during traversal.
- *
- * A directory is excluded when either its basename (e.g. `node_modules`,
- * `__generated__`) or its path relative to the project root (e.g.
- * `src/generated`) matches an entry in `excludedFolders`. Entries may be given
- * with or without a leading `./`.
- *
- * @param {string} itemPath - The path to the directory being considered.
- * @param {string[]} excludedFolders - Folder names or relative paths to exclude.
- * @returns {boolean} - True if the directory should be skipped.
+ * Builds a matcher from gitignore-flavored glob patterns. A pattern without a
+ * slash matches anywhere (by basename); one with a slash is anchored to the
+ * project root; `**` matches any depth; a leading `!` re-includes. Returns a
+ * predicate over project-root-relative paths; never excludes when no positive
+ * patterns are given.
  */
-export function isExcludedFolder(
-  itemPath: string,
-  excludedFolders: string[],
-): boolean {
-  const excluded = new Set(
-    excludedFolders.map(normalizeFolder).filter(Boolean),
-  );
-  if (excluded.size === 0) {
-    return false;
+export function createExcludeMatcher(patterns: string[]): ExcludeMatcher {
+  const cleaned = patterns.map((p) => p.trim()).filter(Boolean);
+  const positives = cleaned.filter((p) => !p.startsWith('!'));
+  const negatives = cleaned
+    .filter((p) => p.startsWith('!'))
+    .map((p) => p.slice(1));
+  if (positives.length === 0) {
+    return () => false;
   }
-  const name = path.basename(itemPath);
-  const relativePath = normalizeFolder(
-    path.relative(baseDir, path.resolve(itemPath)),
-  );
-  return excluded.has(name) || excluded.has(relativePath);
+  const options = { dot: true, basename: true };
+  const matchPositive = picomatch(positives, options);
+  const matchNegative: ExcludeMatcher = negatives.length
+    ? picomatch(negatives, options)
+    : () => false;
+  return (relativePath) =>
+    matchPositive(relativePath) && !matchNegative(relativePath);
 }
 
 /**
- * Recursively finds all files in a directory with the specified extensions.
+ * Recursively finds all files with the given extensions under `dir`, skipping
+ * any directory or file whose project-root-relative path is excluded by
+ * `isExcluded`.
  *
  * @param {string} dir - The directory to start searching from.
  * @param {string[]} extensions - The list of file extensions to match.
- * @param {string[]} excludedFolders - Folder names or relative paths to exclude.
- * @returns {string[]} - An array of file paths that match the given extensions.
+ * @param {ExcludeMatcher} isExcluded - Predicate marking paths to skip.
+ * @returns {string[]} - The matching file paths.
  */
 export function findFilesWithExtension(
   dir: string,
   extensions: string[],
-  excludedFolders: string[],
+  isExcluded: ExcludeMatcher,
 ): string[] {
   let files: string[] = [];
 
@@ -78,12 +73,14 @@ export function findFilesWithExtension(
         return; // Skip this item and continue with the next one
       }
 
+      if (isExcluded(toRelativePosix(itemPath))) {
+        return; // Skip excluded directories and files
+      }
+
       if (stat.isDirectory()) {
-        if (!isExcludedFolder(itemPath, excludedFolders)) {
-          files = files.concat(
-            findFilesWithExtension(itemPath, extensions, excludedFolders),
-          );
-        }
+        files = files.concat(
+          findFilesWithExtension(itemPath, extensions, isExcluded),
+        );
       } else if (extensions.includes(path.extname(item))) {
         files.push(itemPath);
       }

--- a/test/fileUtils.test.ts
+++ b/test/fileUtils.test.ts
@@ -92,6 +92,32 @@ describe('fileUtils', () => {
         'keep.ts',
       ]);
     });
+
+    it('honors file-level "!" re-includes during the walk', () => {
+      (fs.readdirSync as jest.Mock).mockReturnValue([
+        'foo.gen.ts',
+        'keep.gen.ts',
+        'app.ts',
+      ]);
+      (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => false });
+      const matcher = createExcludeMatcher(['*.gen.ts', '!keep.gen.ts']);
+      expect(findFilesWithExtension('./', ['.ts'], matcher).sort()).toEqual([
+        'app.ts',
+        'keep.gen.ts',
+      ]);
+    });
+
+    it('cannot re-include under an excluded directory (gitignore limitation)', () => {
+      (fs.readdirSync as jest.Mock).mockReturnValue(['gen', 'app.ts']);
+      (fs.statSync as jest.Mock).mockImplementation((p: string) => ({
+        isDirectory: () => p.endsWith('gen'),
+      }));
+      // `gen` is pruned before traversal, so `!gen/keep.ts` can't reach inside.
+      const matcher = createExcludeMatcher(['gen', '!gen/keep.ts']);
+      expect(findFilesWithExtension('./', ['.ts'], matcher)).toEqual([
+        'app.ts',
+      ]);
+    });
   });
 
   describe('isOperationUsed', () => {
@@ -175,6 +201,17 @@ describe('fileUtils', () => {
       const ex = createExcludeMatcher(['*.generated.ts', '!keep.generated.ts']);
       expect(ex('src/other.generated.ts')).toBe(true);
       expect(ex('src/keep.generated.ts')).toBe(false);
+    });
+
+    it('lets a negative win regardless of order or which field it came from', () => {
+      // Order-insensitive: a `!` re-include always overrides a positive,
+      // including a positive from the deprecated excludedFolders.
+      expect(createExcludeMatcher(['keep.ts', '!keep.ts'])('src/keep.ts')).toBe(
+        false,
+      );
+      expect(createExcludeMatcher(['!keep.ts', 'keep.ts'])('src/keep.ts')).toBe(
+        false,
+      );
     });
 
     it('excludes nothing when there are no positive patterns', () => {

--- a/test/fileUtils.test.ts
+++ b/test/fileUtils.test.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs';
 import {
+  createExcludeMatcher,
   directoryExists,
   findFilesWithExtension,
-  isExcludedFolder,
   isOperationUsed,
   isOperationUsedInContents,
   readFileContents,
@@ -45,7 +45,7 @@ describe('fileUtils', () => {
         .mockReturnValueOnce({ isDirectory: () => false })
         .mockReturnValueOnce({ isDirectory: () => true });
 
-      const files = findFilesWithExtension('./', ['.ts'], []);
+      const files = findFilesWithExtension('./', ['.ts'], () => false);
       expect(files).toEqual(['file1.ts']); // Adjusted the expected value
     });
 
@@ -54,7 +54,7 @@ describe('fileUtils', () => {
         throw new Error('Failed to read directory');
       });
 
-      const files = findFilesWithExtension('./', ['.ts'], []);
+      const files = findFilesWithExtension('./', ['.ts'], () => false);
       expect(files).toEqual([]); // Expect an empty array since the directory read failed
     });
 
@@ -64,7 +64,7 @@ describe('fileUtils', () => {
         throw new Error('Failed to read file stats');
       });
 
-      const files = findFilesWithExtension('./', ['.ts'], []);
+      const files = findFilesWithExtension('./', ['.ts'], () => false);
       expect(files).toEqual([]); // Expect an empty array since the file stats read failed
     });
 
@@ -74,8 +74,23 @@ describe('fileUtils', () => {
         throw new Error('Failed to read folder stats');
       });
 
-      const files = findFilesWithExtension('./', ['.ts'], []);
+      const files = findFilesWithExtension('./', ['.ts'], () => false);
       expect(files).toEqual([]); // Expect an empty array since the folder stats read failed
+    });
+
+    it('skips excluded directories and files via the matcher', () => {
+      (fs.readdirSync as jest.Mock).mockReturnValue([
+        'keep.ts',
+        'node_modules',
+        'skip.gen.ts',
+      ]);
+      (fs.statSync as jest.Mock).mockImplementation((p: string) => ({
+        isDirectory: () => p.endsWith('node_modules'),
+      }));
+      const matcher = createExcludeMatcher(['node_modules', '*.gen.ts']);
+      expect(findFilesWithExtension('./', ['.ts'], matcher)).toEqual([
+        'keep.ts',
+      ]);
     });
   });
 
@@ -131,30 +146,40 @@ describe('fileUtils', () => {
     });
   });
 
-  describe('isExcludedFolder', () => {
-    it('should exclude by folder basename anywhere in the tree', () => {
-      expect(isExcludedFolder('node_modules', ['node_modules'])).toBe(true);
-      expect(isExcludedFolder('src/api/__generated__', ['__generated__'])).toBe(
-        true,
-      );
+  describe('createExcludeMatcher', () => {
+    it('matches a bare name anywhere by basename', () => {
+      const ex = createExcludeMatcher(['__generated__']);
+      expect(ex('src/api/__generated__')).toBe(true);
+      expect(ex('__generated__')).toBe(true);
+      expect(ex('src/components')).toBe(false);
     });
 
-    it('should accept entries with a leading "./"', () => {
-      expect(isExcludedFolder('node_modules', ['./node_modules'])).toBe(true);
+    it('anchors a pattern that contains a slash to the project root', () => {
+      const ex = createExcludeMatcher(['src/legacy']);
+      expect(ex('src/legacy')).toBe(true);
+      expect(ex('app/src/legacy')).toBe(false);
     });
 
-    it('should exclude by path relative to the project root', () => {
-      expect(isExcludedFolder('src/generated', ['src/generated'])).toBe(true);
+    it('supports ** for any depth and basename globs for files', () => {
+      const ex = createExcludeMatcher(['**/dist', '*.generated.ts']);
+      expect(ex('a/b/dist')).toBe(true);
+      expect(ex('src/x/foo.generated.ts')).toBe(true);
+      expect(ex('src/x/foo.ts')).toBe(false);
     });
 
-    it('should match entries written with Windows backslashes', () => {
-      // path.relative emits backslashes on Windows; config uses forward slashes.
-      expect(isExcludedFolder('src/generated', ['src\\generated'])).toBe(true);
+    it('matches dotfolders like .git', () => {
+      expect(createExcludeMatcher(['.git'])('proj/.git')).toBe(true);
     });
 
-    it('should not exclude unrelated folders', () => {
-      expect(isExcludedFolder('src', ['node_modules'])).toBe(false);
-      expect(isExcludedFolder('src/components', [])).toBe(false);
+    it('re-includes paths matched by a leading "!"', () => {
+      const ex = createExcludeMatcher(['*.generated.ts', '!keep.generated.ts']);
+      expect(ex('src/other.generated.ts')).toBe(true);
+      expect(ex('src/keep.generated.ts')).toBe(false);
+    });
+
+    it('excludes nothing when there are no positive patterns', () => {
+      expect(createExcludeMatcher([])('anything')).toBe(false);
+      expect(createExcludeMatcher(['  ', '!only-neg'])('anything')).toBe(false);
     });
   });
 

--- a/test/gqlPruner.test.ts
+++ b/test/gqlPruner.test.ts
@@ -12,7 +12,7 @@ import {
   mainFunction,
   resolveConfig,
   resolveDirs,
-  resolveExcludedFolders,
+  resolveExcludePatterns,
   resolveFragmentUsagePatterns,
   resolveUsagePatterns,
   scanProject,
@@ -50,26 +50,27 @@ const mockedUnusedFragments =
   fragments.findUnusedFragmentsInCorpus as jest.Mock;
 
 describe('gqlPruner', () => {
-  describe('resolveExcludedFolders', () => {
+  describe('resolveExcludePatterns', () => {
     it('always includes node_modules and .git', () => {
-      expect(resolveExcludedFolders({ graphqlDir: 'g', srcDir: 's' })).toEqual(
+      expect(resolveExcludePatterns({ graphqlDir: 'g', srcDir: 's' })).toEqual(
         DEFAULT_EXCLUDED_FOLDERS,
       );
     });
 
-    it('accepts a single string', () => {
+    it('combines exclude globs with the deprecated excludedFolders', () => {
       expect(
-        resolveExcludedFolders({
+        resolveExcludePatterns({
           graphqlDir: 'g',
           srcDir: 's',
-          excludedFolders: 'legacy',
+          exclude: '**/dist',
+          excludedFolders: ['legacy'],
         }),
-      ).toEqual(['legacy', 'node_modules', '.git']);
+      ).toEqual(['**/dist', 'legacy', 'node_modules', '.git']);
     });
 
-    it('accepts an array and de-dupes the defaults', () => {
+    it('de-dupes against the defaults', () => {
       expect(
-        resolveExcludedFolders({
+        resolveExcludePatterns({
           graphqlDir: 'g',
           srcDir: 's',
           excludedFolders: ['a', 'node_modules'],
@@ -366,7 +367,7 @@ describe('gqlPruner', () => {
   });
 
   describe('formatGeneratedFileWarnings', () => {
-    it('renders a readable line with file, percentage and an excludedFolders hint', () => {
+    it('renders a readable line with file, percentage and an exclude hint', () => {
       const [line] = formatGeneratedFileWarnings([
         {
           file: 'src/gql/graphql.ts',
@@ -378,7 +379,7 @@ describe('gqlPruner', () => {
       ]);
       expect(line).toContain('src/gql/graphql.ts');
       expect(line).toContain('98%');
-      expect(line).toContain('excludedFolders');
+      expect(line).toContain('exclude');
     });
 
     it('returns [] when there are no warnings', () => {
@@ -761,7 +762,7 @@ describe('gqlPruner', () => {
 
       const errs = errorSpy.mock.calls.flat().join('\n');
       expect(errs).toContain('Suspected generated file "src/gql/graphql.ts"');
-      expect(errs).toContain('excludedFolders');
+      expect(errs).toContain('exclude');
 
       const report = JSON.parse(logged());
       expect(report.warnings).toHaveLength(1);

--- a/test/gqlPruner.test.ts
+++ b/test/gqlPruner.test.ts
@@ -77,6 +77,19 @@ describe('gqlPruner', () => {
         }),
       ).toEqual(['a', 'node_modules', '.git']);
     });
+
+    it('carries exclude negations alongside the deprecated excludedFolders', () => {
+      // The matcher is order-insensitive (negatives always win — see
+      // createExcludeMatcher), so this just confirms both fields reach it.
+      expect(
+        resolveExcludePatterns({
+          graphqlDir: 'g',
+          srcDir: 's',
+          excludedFolders: ['legacy'],
+          exclude: ['!legacy/keep.ts'],
+        }),
+      ).toEqual(['!legacy/keep.ts', 'legacy', 'node_modules', '.git']);
+    });
   });
 
   describe('resolveUsagePatterns', () => {


### PR DESCRIPTION
Closes #54.

## What
A single, gitignore-flavored **`exclude`** config key for **files *and* folders**, via glob patterns — superseding the folder-only, exact-match `excludedFolders`:

```yaml
exclude:
  - '**/__generated__'      # folder anywhere by name
  - '*.generated.ts'        # files anywhere by basename
  - 'src/legacy'            # anchored path
  - '!src/keep.generated.ts' # re-include
```

Rules: a name without a slash matches **anywhere by basename**; a slash **anchors** to the project root; `**` matches any depth; a leading `!` **re-includes**.

## How
- **`picomatch`** (zero-dependency glob matcher) with `{ dot: true, basename: true }`. We already walk the FS, so we need a *matcher*, not a globber.
- **`createExcludeMatcher`** (replaces `isExcludedFolder`): positive/negative split so `!` re-includes work predictably.
- **`findFilesWithExtension`** now takes the matcher and applies it at both levels — **prunes matching directories** and **filters matching files** (that's the files-and-folders unification).
- **Backward compatible:** `excludedFolders` is **deprecated** but still honored — folded into the *same* matcher. `basename: true` reproduces its old "name anywhere / path anchored" semantics with **no conversion**, so existing configs behave identically.
- The #22 generated-file masking warning now points at `exclude`.

## Testing
- `createExcludeMatcher`: bare-name-anywhere, slash-anchored, `**` depth, file basename globs, `.git` dotfolder, `!` re-include, empty patterns.
- `findFilesWithExtension`: prunes excluded dirs + filters excluded files via the matcher.
- `resolveExcludePatterns`: merges `exclude` + deprecated `excludedFolders` + defaults, de-duped.
- **Verified e2e:** a real run with `exclude: ['*.generated.ts']` dropped the masking generated *file* ("Found 2 source files" → "1") and surfaced the previously-masked unused operation.
- Full gate green (build, typecheck, lint, **159 tests**) **and `npm ci`** (lockfile validated for the new dep).

## Scope
This is the `exclude` foundation. Follow-ups: `init` auto-adds the detected generated file to `exclude`; and input-selection globs for `graphqlDir`/`srcDir` (#46).

## Dependency
Adds `picomatch` (zero own-dependencies) — the matcher behind micromatch/chokidar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added advanced exclude-pattern support with gitignore-like semantics, including negation (`!`), `**` depth matching, and root-relative rules.
  * Updated configuration to prefer the `exclude` setting while continuing to honor the legacy `excludedFolders` option (deprecated).

* **Bug Fixes**
  * Improved detection and pruning file traversal so excluded files/folders are skipped more accurately.
  * Updated generated-file warning text to reference `exclude`.

* **Documentation**
  * Expanded README and config docs to describe `exclude` behavior and the deprecation of `excludedFolders`.

* **Tests**
  * Refreshed unit tests to validate the new exclude matcher and updated warning messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->