### PR TITLE
feat(init): auto-detect a generated file and pre-fill it into `exclude`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ gqlPrune guards against this. When one source file alone references most of your
 
 > ⚠ Suspected generated file "src/gql/graphql.ts" references 100% of all operations (50/50) and looks generated — add it to "exclude" in gqlPrune.config.yaml or unused results will be unreliable.
 
-Add it to `exclude` (e.g. `'**/*.generated.ts'`) and re-run. The warning goes to **stderr** (so it also surfaces in `--json` mode) and is included in the JSON report's `warnings` array; it does not change the exit code.
+Add it to `exclude` (e.g. `'**/*.generated.ts'`) and re-run — or just run `gqlprune init`, which detects such a file and pre-fills it into `exclude` for you. The warning goes to **stderr** (so it also surfaces in `--json` mode) and is included in the JSON report's `warnings` array; it does not change the exit code.
 
 ## Setup
 
@@ -66,7 +66,7 @@ npm install --save-dev gqlprune
 
 ### Configuration
 
-Run the `init` command to launch a configurator that generates `gqlPrune.config.yaml` at the root of your project. It **auto-detects** your GraphQL and source directories (scanning the project, excluding `node_modules`/`.git`/`dist`) and offers them as defaults you can accept or override. After writing the file it prints a quick **preview** of what a real run would find:
+Run the `init` command to launch a configurator that generates `gqlPrune.config.yaml` at the root of your project. It **auto-detects** your GraphQL and source directories (scanning the project, excluding `node_modules`/`.git`/`dist`) and offers them as defaults you can accept or override. It also **detects a generated file that would mask your results** (the [false "all clear"](#avoiding-false-all-clear-results) trap) and **pre-fills it into `exclude`**, so your first run is truthful. After writing the file it prints a quick **preview** of what a real run would find:
 
 ```bash
 npx gqlprune init
@@ -79,10 +79,11 @@ npx gqlprune init
 ```yaml
 graphqlDir: ./path/to/graphql
 srcDir: ./src
-# Glob patterns (gitignore-flavored) for files/folders to skip.
+# Files/folders to skip (gitignore-flavored globs). `init` pre-fills any
+# generated file it detects (it would otherwise mask all results); add more.
 exclude:
+  - src/gql/graphql.ts
   - '**/__generated__'
-  - '**/*.generated.ts'
 # Optional — override how operation usage is detected.
 # Supports {name}, {Name}, {type}, {Type} placeholders.
 usagePatterns:

--- a/src/core/configGenerator.ts
+++ b/src/core/configGenerator.ts
@@ -13,9 +13,31 @@ import { GqlPruneConfig } from '../types/GqlPruneConfig.js';
 // Folders never worth scanning when auto-detecting the project layout.
 const isDetectExcluded = createExcludeMatcher(['node_modules', '.git', 'dist']);
 
-/** Splits a comma-separated input into a trimmed list of folder names. */
+/** Splits a comma-separated input into a trimmed list, dropping empty entries. */
 export function splitFolders(input: string): string[] {
-  return input.split(',').map((folder) => folder.trim());
+  return input
+    .split(',')
+    .map((folder) => folder.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Detects source files that would mask unused results (a generated file inside
+ * `srcDir` referencing most operations — see {@link detectGeneratedFiles}) so
+ * `init` can pre-fill them into `exclude`. Returns their project-root-relative
+ * paths, or `[]` when a directory is missing (nothing to scan yet).
+ */
+export function detectGeneratedExcludes(
+  graphqlDir: string,
+  srcDir: string,
+): string[] {
+  const dirs = [...resolveDirs(graphqlDir), ...resolveDirs(srcDir)];
+  if (dirs.length === 0 || dirs.some((dir) => !directoryExists(dir))) {
+    return [];
+  }
+  return scanProject({ graphqlDir, srcDir }).generatedFiles.map((warning) =>
+    warning.file.replace(/\\/g, '/'),
+  );
 }
 
 /**
@@ -84,24 +106,39 @@ function printPreview(config: GqlPruneConfig): void {
 }
 
 export async function generateConfig() {
+  const graphqlDefault = detectGraphqlDir() ?? './path/to/graphql';
+  const srcDefault = detectSrcDir() ?? './path/to/src';
+
+  // Reuse the generated-file detector so a fresh config excludes any file that
+  // would otherwise reference every operation and mask all unused results.
+  const detectedExcludes = detectGeneratedExcludes(graphqlDefault, srcDefault);
+  if (detectedExcludes.length > 0) {
+    console.log(
+      `⚠ Detected a likely generated file that references most operations: ${detectedExcludes.join(
+        ', ',
+      )}\n  Pre-filling it into "exclude" so results aren't masked — edit or clear it if that's not right.`,
+    );
+  }
+
   const questions = [
     {
       type: 'input',
       name: 'graphqlDir',
       message: 'Enter the path to your GraphQL directory:',
-      default: detectGraphqlDir() ?? './path/to/graphql',
+      default: graphqlDefault,
     },
     {
       type: 'input',
       name: 'srcDir',
       message: 'Enter the path to your source directory:',
-      default: detectSrcDir() ?? './path/to/src',
+      default: srcDefault,
     },
     {
       type: 'input',
-      name: 'excludedFolders',
-      message: 'Enter the folders to exclude (comma separated if multiple):',
-      default: 'node_modules',
+      name: 'exclude',
+      message:
+        'Files or folders to exclude (comma separated; gitignore-style globs allowed):',
+      default: detectedExcludes.join(', '),
       filter: splitFolders,
     },
   ];
@@ -112,6 +149,6 @@ export async function generateConfig() {
   fs.writeFileSync('./gqlPrune.config.yaml', yaml.dump(answers));
   console.log('Configuration generated successfully!');
 
-  // Level 3: show an instant preview of what a real run would find.
+  // Show an instant preview of what a real run would find.
   printPreview(answers as GqlPruneConfig);
 }

--- a/src/core/gqlPruner.ts
+++ b/src/core/gqlPruner.ts
@@ -420,6 +420,9 @@ export type ScanResult = {
   unusedOperations: OperationInfo[];
   unusedFragments: FragmentInfo[];
   generatedWarnings: string[];
+  /** Raw suspected-generated files, so callers can act on the paths (e.g.
+   * `gqlprune init` pre-filling them into `exclude`), not just the messages. */
+  generatedFiles: GeneratedFileWarning[];
 };
 
 /**
@@ -464,8 +467,10 @@ export function scanProject(config: GqlPruneConfig): ScanResult {
     fileContents,
     fragmentUsagePatterns,
   );
-  const generatedWarnings = formatGeneratedFileWarnings(
-    detectGeneratedFiles(sources, operations, usagePatterns),
+  const generatedFiles = detectGeneratedFiles(
+    sources,
+    operations,
+    usagePatterns,
   );
 
   return {
@@ -474,7 +479,8 @@ export function scanProject(config: GqlPruneConfig): ScanResult {
     operationCount: operations.length,
     unusedOperations,
     unusedFragments,
-    generatedWarnings,
+    generatedWarnings: formatGeneratedFileWarnings(generatedFiles),
+    generatedFiles,
   };
 }
 

--- a/test/configGenerator.test.ts
+++ b/test/configGenerator.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import inquirer from 'inquirer';
 import {
   commonParentDir,
+  detectGeneratedExcludes,
   detectGraphqlDir,
   detectSrcDir,
   generateConfig,
@@ -49,6 +50,39 @@ describe('configGenerator', () => {
 
     it('returns a single-element list for one folder', () => {
       expect(splitFolders('node_modules')).toEqual(['node_modules']);
+    });
+
+    it('drops empty entries (e.g. an empty default)', () => {
+      expect(splitFolders('')).toEqual([]);
+      expect(splitFolders('a, , b')).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('detectGeneratedExcludes', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('returns the detected generated file paths when the dirs exist', () => {
+      mockFsTree({}, new Set(['./graphql', './src']));
+      mockedScan.mockReturnValue({
+        generatedFiles: [
+          {
+            file: 'src/gql/graphql.ts',
+            coverage: 1,
+            matchedOperations: 5,
+            totalOperations: 5,
+            reasons: ['coverage', 'filename'],
+          },
+        ],
+      });
+      expect(detectGeneratedExcludes('./graphql', './src')).toEqual([
+        'src/gql/graphql.ts',
+      ]);
+    });
+
+    it('returns [] without scanning when a directory is missing', () => {
+      mockFsTree({}, new Set(['./graphql'])); // ./src does not exist
+      expect(detectGeneratedExcludes('./graphql', './src')).toEqual([]);
+      expect(mockedScan).not.toHaveBeenCalled();
     });
   });
 
@@ -130,7 +164,7 @@ describe('configGenerator', () => {
       (inquirer.prompt as unknown as jest.Mock).mockResolvedValue({
         graphqlDir: './graphql',
         srcDir: './src',
-        excludedFolders: ['node_modules'],
+        exclude: ['node_modules'],
       });
 
       await generateConfig();
@@ -141,6 +175,9 @@ describe('configGenerator', () => {
       expect(file).toBe('./gqlPrune.config.yaml');
       expect(contents).toContain('graphqlDir: ./graphql');
       expect(contents).toContain('srcDir: ./src');
+      // init now writes the new `exclude` field, not the deprecated alias.
+      expect(contents).toContain('exclude:');
+      expect(contents).not.toContain('excludedFolders');
       expect(logSpy.mock.calls.flat().join('\n')).toContain(
         'Configuration generated',
       );
@@ -154,7 +191,7 @@ describe('configGenerator', () => {
       (inquirer.prompt as unknown as jest.Mock).mockResolvedValue({
         graphqlDir: './graphql',
         srcDir: './src',
-        excludedFolders: ['node_modules'],
+        exclude: [],
       });
 
       await generateConfig();
@@ -173,7 +210,7 @@ describe('configGenerator', () => {
       (inquirer.prompt as unknown as jest.Mock).mockResolvedValue({
         graphqlDir: './graphql',
         srcDir: './src',
-        excludedFolders: ['node_modules'],
+        exclude: [],
       });
       mockedScan.mockReturnValue({
         gqlFileCount: 12,
@@ -186,6 +223,7 @@ describe('configGenerator', () => {
         }),
         unusedFragments: [],
         generatedWarnings: [],
+        generatedFiles: [],
       });
 
       await generateConfig();
@@ -194,6 +232,47 @@ describe('configGenerator', () => {
       expect(out).toContain('42');
       expect(out).toContain('12');
       expect(out).toContain('5');
+    });
+
+    it('pre-fills the exclude prompt with a detected generated file and warns', async () => {
+      mockFsTree(
+        { '.': ['graphql'], graphql: ['ops.gql'] },
+        new Set(['graphql', 'src', './graphql', './src']),
+      );
+      mockedScan.mockReturnValue({
+        gqlFileCount: 1,
+        sourceFileCount: 1,
+        operationCount: 5,
+        unusedOperations: [],
+        unusedFragments: [],
+        generatedWarnings: [],
+        generatedFiles: [
+          {
+            file: 'src/gql/graphql.ts',
+            coverage: 1,
+            matchedOperations: 5,
+            totalOperations: 5,
+            reasons: ['coverage', 'filename'],
+          },
+        ],
+      });
+      (inquirer.prompt as unknown as jest.Mock).mockResolvedValue({
+        graphqlDir: './graphql',
+        srcDir: './src',
+        exclude: ['src/gql/graphql.ts'],
+      });
+
+      await generateConfig();
+
+      const questions = (inquirer.prompt as unknown as jest.Mock).mock
+        .calls[0][0];
+      const byName = Object.fromEntries(
+        questions.map((q: { name: string }) => [q.name, q]),
+      );
+      expect(byName.exclude.default).toBe('src/gql/graphql.ts');
+      expect(logSpy.mock.calls.flat().join('\n')).toContain(
+        'src/gql/graphql.ts',
+      );
     });
   });
 });

--- a/test/gqlPruner.test.ts
+++ b/test/gqlPruner.test.ts
@@ -524,6 +524,33 @@ describe('gqlPruner', () => {
       expect(result.unusedOperations.map((op) => op.name)).toEqual(['Unused']);
       expect(result.unusedFragments).toEqual([]);
       expect(result.generatedWarnings).toEqual([]);
+      expect(result.generatedFiles).toEqual([]);
+    });
+
+    it('exposes the raw detected generated files (for init auto-exclude)', () => {
+      const ops = ['A', 'B', 'C', 'D', 'E'].map((name) => ({
+        name,
+        type: 'query' as const,
+        filePath: 'a.gql',
+      }));
+      mockedFind
+        .mockReturnValueOnce(['a.gql']) // gql files
+        .mockReturnValueOnce(['graphql.ts']); // source files
+      mockedExtract.mockReturnValue(ops);
+      // One file references every operation (via {Name}Document) → coverage 1.0.
+      mockedReadSources.mockReturnValue([
+        {
+          file: 'src/gql/graphql.ts',
+          content: 'ADocument BDocument CDocument DDocument EDocument',
+        },
+      ]);
+
+      const result = scanProject({ graphqlDir: './g', srcDir: './s' });
+
+      expect(result.generatedFiles.map((w) => w.file)).toEqual([
+        'src/gql/graphql.ts',
+      ]);
+      expect(result.generatedWarnings).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
Closes #57. Follow-up of #54.

## What
`gqlprune init` now prevents the #1 false-"all clear" footgun automatically. After detecting your GraphQL/source dirs, it reuses the #22 detector to find a source file that references *most* operations (a generated file that would mask everything as "used") and **pre-fills it into `exclude`**:

```
⚠ Detected a likely generated file that references most operations: src/gql/graphql.ts
  Pre-filling it into "exclude" so results aren't masked — edit or clear it if that's not right.
```

It also **migrates `init` to the new `exclude` field** (gitignore-flavored globs from #54) instead of generating the deprecated `excludedFolders`.

## Why
Before this, a fresh `init` on a codegen project produced a config whose *first* `gqlprune` run reported nothing unused — silently wrong. Now the masking file is excluded from the start.

## How
- `scanProject` returns the raw `generatedFiles: GeneratedFileWarning[]` (not just the formatted `generatedWarnings` strings), so callers can act on the paths.
- `detectGeneratedExcludes(graphqlDir, srcDir)` returns those paths, scanning only when both dirs exist (mirrors the preview guard).
- `generateConfig` runs detection on the detected dir defaults, prints a heads-up, and seeds the `exclude` prompt default — so it's pre-filled but editable.
- `splitFolders` now drops empty entries (an empty `exclude` default → `[]`, not `['']`).

## Testing
- `scanProject` exposes `generatedFiles` (+ a detection case); `detectGeneratedExcludes` (detects / guards on missing dir); `generateConfig` (writes `exclude` not `excludedFolders`, pre-fills + warns on a detected file); `splitFolders` empty-filter.
- **E2E (real fs):** `detectGeneratedExcludes` → `['src/gql/graphql.ts']`; without it the scan reports `[]` (masked), with it the previously-hidden ops surface. Gate green: **168 tests**, coverage 98%.

## Decisions (sensible defaults, flagged per CONTRIBUTING)
- **Pre-filled, not silent:** the detected file is shown as the editable prompt default rather than written without consent.
- **Detection uses the detected dir defaults** (not post-prompt answers), so it's a single up-front scan; if you override the dirs in the prompt, just adjust `exclude`.
- **Out of scope:** the `--ignore` CLI flag still maps to `excludedFolders` (deprecated but honored) — migrating flags is a separate concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Setup now pre-fills likely generated files into the exclusion list and shows a preview of what a full scan would find.
  - Generated-file detection is more accurate, helping avoid misleading “all clear” results on the first run.

- **Documentation**
  - Updated setup guidance and configuration examples to reflect the new exclusion behavior and recommended initialization flow.

- **Bug Fixes**
  - Improved handling of comma-separated folder inputs by ignoring empty entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->