### PR TITLE
feat(cli): add --verbose flag to explain scan verdicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,28 @@ npx gqlprune --json
 
 Only the JSON is written to stdout and the exit code is unchanged (0 clean / 1 unused), so it pipes cleanly into `jq` and CI gates. The `warnings` array carries advisory messages — currently a heads-up when a [generated file may be masking results](#avoiding-false-all-clear-results) — and is empty when there are none.
 
+### Verbose output
+
+Pass `--verbose` to see *why* each operation was judged used or unused — the resolved configuration, the files scanned, and per operation the exact search string that matched and the file it matched in:
+
+```bash
+npx gqlprune --verbose
+```
+
+```text
+[verbose] graphqlDir: ./graphql
+[verbose] srcDir: ./src
+[verbose] exclude: node_modules, .git
+[verbose] usagePatterns: use{Name}{Type}, use{Name}Lazy{Type}, use{Name}Suspense{Type}, {Name}Document
+[verbose] fragmentUsagePatterns: {Name}FragmentDoc
+[verbose] GraphQL files (1): graphql/user.gql
+[verbose] Source files scanned: 42
+[verbose] used:   GetUser (query) — "useGetUserQuery" found in src/App.tsx
+[verbose] unused: OldQuery (query) — no match for useOldQueryQuery, useOldQueryLazyQuery, useOldQuerySuspenseQuery, OldQueryDocument
+```
+
+This is the fastest way to debug a surprising result: an operation you believe is used shows exactly which patterns were searched, and if *every* operation matches in the same file, that file is almost certainly [generated output masking your results](#avoiding-false-all-clear-results). Verbose lines go to **stderr**, so `--verbose --json` still emits pure JSON on stdout.
+
 ### In CI
 
 Add a script and run it in your pipeline; the non-zero exit fails the job when unused operations are found:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { parseArgs } from './utils/args.js';
 import { notifyUpdate } from './utils/updateNotifier.js';
 import { pkg } from './utils/pkgInfo.js';
 
-const { command, json, annotate, version, config } = parseArgs(
+const { command, json, annotate, version, verbose, config } = parseArgs(
   process.argv.slice(2),
 );
 
@@ -21,6 +21,7 @@ async function run(): Promise<void> {
     mainFunction({
       json,
       annotate: annotate || process.env.GITHUB_ACTIONS === 'true',
+      verbose,
       config,
     });
   }

--- a/src/core/gqlPruner.ts
+++ b/src/core/gqlPruner.ts
@@ -93,6 +93,39 @@ export function findUnusedOperations(
   });
 }
 
+/** How a single operation's used/unused verdict was reached. */
+export type OperationUsage = {
+  operation: OperationInfo;
+  /** The concrete search strings expanded from the usage patterns. */
+  patterns: string[];
+  /** The first pattern/file hit; absent when the operation is unused. */
+  match?: { pattern: string; file: string };
+};
+
+/**
+ * Determines, for every operation, whether it is referenced in the sources —
+ * and when it is, which expanded pattern matched in which file. The unused set
+ * derived from this (`!usage.match`) is identical to `findUnusedOperations`;
+ * the extra detail exists so `--verbose` can explain each verdict.
+ */
+export function explainOperationUsage(
+  operations: OperationInfo[],
+  sources: SourceFile[],
+  usagePatterns: string[],
+): OperationUsage[] {
+  return operations.map((operation) => {
+    const patterns = buildUsagePatterns(operation, usagePatterns);
+    for (const { file, content } of sources) {
+      for (const pattern of patterns) {
+        if (content.includes(pattern)) {
+          return { operation, patterns, match: { pattern, file } };
+        }
+      }
+    }
+    return { operation, patterns };
+  });
+}
+
 /** Prints the aligned table of unused operations. */
 function reportUnusedOperations(unusedOperations: OperationInfo[]): void {
   const maxTypeLength = Math.max(
@@ -417,6 +450,10 @@ export type ScanResult = {
   gqlFileCount: number;
   sourceFileCount: number;
   operationCount: number;
+  /** The `.gql`/`.graphql` files that were scanned. */
+  gqlFiles: string[];
+  /** Per-operation verdicts with the matching pattern/file (see `--verbose`). */
+  operationUsages: OperationUsage[];
   unusedOperations: OperationInfo[];
   unusedFragments: FragmentInfo[];
   generatedWarnings: string[];
@@ -424,6 +461,38 @@ export type ScanResult = {
    * `gqlprune init` pre-filling them into `exclude`), not just the messages. */
   generatedFiles: GeneratedFileWarning[];
 };
+
+/** Renders the resolved configuration as `--verbose` lines. */
+export function formatVerboseConfigLines(config: GqlPruneConfig): string[] {
+  const list = (values: string[]): string => values.join(', ');
+  return [
+    `graphqlDir: ${list(resolveDirs(config.graphqlDir))}`,
+    `srcDir: ${list(resolveDirs(config.srcDir))}`,
+    `exclude: ${list(resolveExcludePatterns(config))}`,
+    `usagePatterns: ${list(resolveUsagePatterns(config))}`,
+    `fragmentUsagePatterns: ${list(resolveFragmentUsagePatterns(config))}`,
+  ];
+}
+
+/**
+ * Renders the scan's findings as `--verbose` lines: the files scanned, then one
+ * verdict per operation — with the matching pattern and file for used ones, and
+ * the searched-but-unmatched patterns for unused ones.
+ */
+export function formatVerboseScanLines(result: ScanResult): string[] {
+  const lines = [
+    `GraphQL files (${result.gqlFiles.length}): ${result.gqlFiles.join(', ')}`,
+    `Source files scanned: ${result.sourceFileCount}`,
+  ];
+  for (const { operation, patterns, match } of result.operationUsages) {
+    lines.push(
+      match
+        ? `used:   ${operation.name} (${operation.type}) — "${match.pattern}" found in ${match.file}`
+        : `unused: ${operation.name} (${operation.type}) — no match for ${patterns.join(', ')}`,
+    );
+  }
+  return lines;
+}
 
 /**
  * Runs one full scan for the given config and returns the results without
@@ -457,11 +526,16 @@ export function scanProject(config: GqlPruneConfig): ScanResult {
   const sources = readSourceFiles(tsFiles);
   const fileContents = sources.map((source) => source.content);
 
-  const unusedOperations = findUnusedOperations(
+  // One sweep yields both the unused set and the per-operation explanations
+  // that `--verbose` reports.
+  const operationUsages = explainOperationUsage(
     operations,
-    fileContents,
+    sources,
     usagePatterns,
   );
+  const unusedOperations = operationUsages
+    .filter((usage) => !usage.match)
+    .map((usage) => usage.operation);
   const unusedFragments = findUnusedFragmentsInCorpus(
     gqlFiles,
     fileContents,
@@ -477,6 +551,8 @@ export function scanProject(config: GqlPruneConfig): ScanResult {
     gqlFileCount: gqlFiles.length,
     sourceFileCount: tsFiles.length,
     operationCount: operations.length,
+    gqlFiles,
+    operationUsages,
     unusedOperations,
     unusedFragments,
     generatedWarnings: formatGeneratedFileWarnings(generatedFiles),
@@ -485,10 +561,22 @@ export function scanProject(config: GqlPruneConfig): ScanResult {
 }
 
 export function mainFunction(
-  options: { json?: boolean; annotate?: boolean; config?: CliConfig } = {},
+  options: {
+    json?: boolean;
+    annotate?: boolean;
+    verbose?: boolean;
+    config?: CliConfig;
+  } = {},
 ) {
   const json = options.json ?? false;
   const annotate = options.annotate ?? false;
+  const verbose = options.verbose ?? false;
+  // Verbose lines go to stderr so stdout stays clean for --json.
+  const logVerbose = (lines: string[]): void => {
+    for (const line of lines) {
+      console.error(kleur.dim(`[verbose] ${line}`));
+    }
+  };
 
   let resolved: Partial<GqlPruneConfig>;
   try {
@@ -532,6 +620,11 @@ export function mainFunction(
 
   // ---------------- Main Logic ----------------
 
+  if (verbose) {
+    logVerbose(formatVerboseConfigLines(config));
+  }
+
+  const result = scanProject(config);
   const {
     gqlFileCount,
     sourceFileCount,
@@ -539,7 +632,11 @@ export function mainFunction(
     unusedOperations,
     unusedFragments,
     generatedWarnings,
-  } = scanProject(config);
+  } = result;
+
+  if (verbose) {
+    logVerbose(formatVerboseScanLines(result));
+  }
 
   if (!json) {
     console.log(

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -5,6 +5,7 @@ export type CliOptions = {
   json: boolean;
   annotate: boolean;
   version: boolean;
+  verbose: boolean;
   config: CliConfig;
 };
 
@@ -12,10 +13,11 @@ export type CliOptions = {
  * Parses CLI arguments (everything after the node binary and script path).
  *
  * Recognizes the optional `init` command, the boolean `--json` / `--annotate`
- * flags, and value flags that mirror the config file: `--graphql`, `--src`,
- * and the repeatable `--ignore`, `--pattern`, `--fragment-pattern`. Value flags
- * accept both `--flag value` and `--flag=value`, in any order. A value is never
- * mistaken for the positional command.
+ * / `--verbose` flags, and value flags that mirror the config file:
+ * `--graphql`, `--src`, and the repeatable `--ignore`, `--pattern`,
+ * `--fragment-pattern`. Value flags accept both `--flag value` and
+ * `--flag=value`, in any order. A value is never mistaken for the positional
+ * command.
  *
  * @param {string[]} argv - Arguments, e.g. `process.argv.slice(2)`.
  * @returns {CliOptions} - The resolved command, flags, and CLI config overrides.
@@ -29,6 +31,7 @@ export function parseArgs(argv: string[]): CliOptions {
   let json = false;
   let annotate = false;
   let version = false;
+  let verbose = false;
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -62,6 +65,9 @@ export function parseArgs(argv: string[]): CliOptions {
         break;
       case '--annotate':
         annotate = true;
+        break;
+      case '--verbose':
+        verbose = true;
         break;
       case '--version':
       case '-v':
@@ -103,5 +109,5 @@ export function parseArgs(argv: string[]): CliOptions {
     config.fragmentUsagePatterns = fragmentUsagePatterns;
   }
 
-  return { command, json, annotate, version, config };
+  return { command, json, annotate, version, verbose, config };
 }

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -7,6 +7,7 @@ describe('parseArgs', () => {
       json: false,
       annotate: false,
       version: false,
+      verbose: false,
       config: {},
     });
   });
@@ -17,6 +18,7 @@ describe('parseArgs', () => {
       json: false,
       annotate: false,
       version: false,
+      verbose: false,
       config: {},
     });
   });
@@ -27,6 +29,7 @@ describe('parseArgs', () => {
       json: true,
       annotate: false,
       version: false,
+      verbose: false,
       config: {},
     });
   });
@@ -37,8 +40,26 @@ describe('parseArgs', () => {
       json: false,
       annotate: true,
       version: false,
+      verbose: false,
       config: {},
     });
+  });
+
+  it('parses the --verbose flag', () => {
+    expect(parseArgs(['--verbose'])).toEqual({
+      command: undefined,
+      json: false,
+      annotate: false,
+      version: false,
+      verbose: true,
+      config: {},
+    });
+  });
+
+  it('combines --verbose with other flags', () => {
+    const result = parseArgs(['--verbose', '--json']);
+    expect(result.verbose).toBe(true);
+    expect(result.json).toBe(true);
   });
 
   it('parses --version and the -v short flag', () => {
@@ -53,6 +74,7 @@ describe('parseArgs', () => {
       json: true,
       annotate: true,
       version: false,
+      verbose: false,
       config: {},
     });
   });
@@ -111,6 +133,7 @@ describe('parseArgs', () => {
       json: true,
       annotate: false,
       version: false,
+      verbose: false,
       config: { graphqlDir: './g', srcDir: './s', excludedFolders: ['x'] },
     });
   });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -78,6 +78,7 @@ describe('cli dispatch', () => {
     expect(mainFunction).toHaveBeenCalledWith({
       json: false,
       annotate: false,
+      verbose: false,
       config: {},
     });
     expect(generateConfig).not.toHaveBeenCalled();
@@ -96,6 +97,7 @@ describe('cli dispatch', () => {
     expect(mainFunction).toHaveBeenCalledWith({
       json: true,
       annotate: false,
+      verbose: false,
       config: {},
     });
   });
@@ -105,6 +107,17 @@ describe('cli dispatch', () => {
     expect(mainFunction).toHaveBeenCalledWith({
       json: false,
       annotate: true,
+      verbose: false,
+      config: {},
+    });
+  });
+
+  it('passes --verbose through to the pruner', () => {
+    const { mainFunction } = runCli(['--verbose']);
+    expect(mainFunction).toHaveBeenCalledWith({
+      json: false,
+      annotate: false,
+      verbose: true,
       config: {},
     });
   });
@@ -114,6 +127,7 @@ describe('cli dispatch', () => {
     expect(mainFunction).toHaveBeenCalledWith({
       json: false,
       annotate: true,
+      verbose: false,
       config: {},
     });
   });
@@ -123,6 +137,7 @@ describe('cli dispatch', () => {
     expect(mainFunction).toHaveBeenCalledWith({
       json: false,
       annotate: false,
+      verbose: false,
       config: { graphqlDir: './g', srcDir: './s' },
     });
   });

--- a/test/gqlPruner.test.ts
+++ b/test/gqlPruner.test.ts
@@ -6,9 +6,12 @@ import {
   buildJsonReport,
   DEFAULT_EXCLUDED_FOLDERS,
   detectGeneratedFiles,
+  explainOperationUsage,
   findUnusedOperations,
   formatAnnotations,
   formatGeneratedFileWarnings,
+  formatVerboseConfigLines,
+  formatVerboseScanLines,
   mainFunction,
   resolveConfig,
   resolveDirs,
@@ -178,6 +181,132 @@ describe('gqlPruner', () => {
           DEFAULT_USAGE_PATTERNS,
         ),
       ).toEqual([]);
+    });
+  });
+
+  describe('explainOperationUsage', () => {
+    const ops: OperationInfo[] = [
+      { name: 'GetUser', type: 'query', filePath: 'a.gql' },
+      { name: 'Unused', type: 'query', filePath: 'a.gql' },
+    ];
+    const sources = [
+      { file: 'src/App.tsx', content: 'const r = useGetUserQuery()' },
+      { file: 'src/Other.tsx', content: 'nothing here' },
+    ];
+
+    it('records the matching pattern and file for a used operation', () => {
+      const [usage] = explainOperationUsage(
+        [ops[0]],
+        sources,
+        DEFAULT_USAGE_PATTERNS,
+      );
+      expect(usage.operation.name).toBe('GetUser');
+      expect(usage.match).toEqual({
+        pattern: 'useGetUserQuery',
+        file: 'src/App.tsx',
+      });
+    });
+
+    it('leaves match absent for an unused operation, keeping the searched patterns', () => {
+      const [usage] = explainOperationUsage(
+        [ops[1]],
+        sources,
+        DEFAULT_USAGE_PATTERNS,
+      );
+      expect(usage.match).toBeUndefined();
+      expect(usage.patterns).toEqual([
+        'useUnusedQuery',
+        'useUnusedLazyQuery',
+        'useUnusedSuspenseQuery',
+        'UnusedDocument',
+      ]);
+    });
+
+    it('agrees with findUnusedOperations on the unused set', () => {
+      const usages = explainOperationUsage(
+        ops,
+        sources,
+        DEFAULT_USAGE_PATTERNS,
+      );
+      const unusedViaExplain = usages
+        .filter((usage) => !usage.match)
+        .map((usage) => usage.operation);
+      expect(unusedViaExplain).toEqual(
+        findUnusedOperations(
+          ops,
+          sources.map((source) => source.content),
+          DEFAULT_USAGE_PATTERNS,
+        ),
+      );
+    });
+
+    it('returns [] for no operations', () => {
+      expect(
+        explainOperationUsage([], sources, DEFAULT_USAGE_PATTERNS),
+      ).toEqual([]);
+    });
+  });
+
+  describe('formatVerboseConfigLines', () => {
+    it('renders the resolved dirs, excludes and patterns', () => {
+      const lines = formatVerboseConfigLines({
+        graphqlDir: './g',
+        srcDir: ['./s1', './s2'],
+        exclude: '**/dist',
+        usagePatterns: ['{Name}Doc'],
+      });
+      const text = lines.join('\n');
+      expect(text).toContain('graphqlDir: ./g');
+      expect(text).toContain('srcDir: ./s1, ./s2');
+      expect(text).toContain('exclude: **/dist, node_modules, .git');
+      expect(text).toContain('usagePatterns: {Name}Doc');
+      expect(text).toContain('fragmentUsagePatterns: {Name}FragmentDoc');
+    });
+  });
+
+  describe('formatVerboseScanLines', () => {
+    const baseResult = {
+      gqlFileCount: 1,
+      sourceFileCount: 3,
+      operationCount: 2,
+      gqlFiles: ['graphql/user.gql'],
+      unusedOperations: [],
+      unusedFragments: [],
+      generatedWarnings: [],
+      generatedFiles: [],
+    };
+
+    it('lists the gql files, source count, and one verdict line per operation', () => {
+      const lines = formatVerboseScanLines({
+        ...baseResult,
+        operationUsages: [
+          {
+            operation: { name: 'GetUser', type: 'query', filePath: 'a.gql' },
+            patterns: ['useGetUserQuery'],
+            match: { pattern: 'useGetUserQuery', file: 'src/App.tsx' },
+          },
+          {
+            operation: { name: 'Dead', type: 'mutation', filePath: 'a.gql' },
+            patterns: ['useDeadMutation', 'DeadDocument'],
+          },
+        ],
+      });
+      const text = lines.join('\n');
+      expect(text).toContain('GraphQL files (1): graphql/user.gql');
+      expect(text).toContain('Source files scanned: 3');
+      expect(text).toContain('GetUser');
+      expect(text).toContain('"useGetUserQuery" found in src/App.tsx');
+      expect(text).toContain('Dead');
+      expect(text).toContain('useDeadMutation, DeadDocument');
+    });
+
+    it('handles a scan with no operations', () => {
+      const lines = formatVerboseScanLines({
+        ...baseResult,
+        operationCount: 0,
+        operationUsages: [],
+      });
+      expect(lines.join('\n')).toContain('Source files scanned: 3');
     });
   });
 
@@ -527,6 +656,29 @@ describe('gqlPruner', () => {
       expect(result.generatedFiles).toEqual([]);
     });
 
+    it('exposes the scanned gql files and a usage explanation per operation', () => {
+      mockedFind
+        .mockReturnValueOnce(['a.gql']) // gql files
+        .mockReturnValueOnce(['App.tsx']); // source files
+      mockedExtract.mockReturnValue([
+        { name: 'GetUser', type: 'query', filePath: 'a.gql' },
+        { name: 'Unused', type: 'query', filePath: 'a.gql' },
+      ]);
+      mockedReadSources.mockReturnValue([
+        { file: 'App.tsx', content: 'useGetUserQuery()' },
+      ]);
+
+      const result = scanProject({ graphqlDir: './g', srcDir: './s' });
+
+      expect(result.gqlFiles).toEqual(['a.gql']);
+      expect(result.operationUsages).toHaveLength(2);
+      expect(result.operationUsages[0].match).toEqual({
+        pattern: 'useGetUserQuery',
+        file: 'App.tsx',
+      });
+      expect(result.operationUsages[1].match).toBeUndefined();
+    });
+
     it('exposes the raw detected generated files (for init auto-exclude)', () => {
       const ops = ['A', 'B', 'C', 'D', 'E'].map((name) => ({
         name,
@@ -839,6 +991,84 @@ describe('gqlPruner', () => {
       expect(errs).toContain('::warning::Suspected generated file');
       // The "%" in "100%" is escaped for the workflow command.
       expect(errs).toContain('100%25');
+    });
+
+    it('logs the resolved config and per-operation verdicts to stderr with --verbose', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        'graphqlDir: ./g\nsrcDir: ./s\n',
+      );
+      mockedDirExists.mockReturnValue(true);
+      mockedFind
+        .mockReturnValueOnce(['a.gql'])
+        .mockReturnValueOnce(['App.tsx']);
+      mockedExtract.mockReturnValue([
+        { name: 'GetUser', type: 'query', filePath: 'a.gql' },
+        { name: 'Dead', type: 'query', filePath: 'a.gql' },
+      ]);
+      mockedReadSources.mockReturnValue([
+        { file: 'App.tsx', content: 'const r = useGetUserQuery()' },
+      ]);
+
+      mainFunction({ verbose: true });
+
+      const errs = errorSpy.mock.calls.flat().join('\n');
+      expect(errs).toContain('graphqlDir: ./g');
+      expect(errs).toContain('srcDir: ./s');
+      expect(errs).toContain('GraphQL files (1): a.gql');
+      expect(errs).toContain('"useGetUserQuery" found in App.tsx');
+      expect(errs).toContain('Dead');
+      // Verbose lines must never leak to stdout.
+      expect(logged()).not.toContain('found in App.tsx');
+    });
+
+    it('keeps stdout pure JSON when --verbose and --json are combined', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        'graphqlDir: ./g\nsrcDir: ./s\n',
+      );
+      mockedDirExists.mockReturnValue(true);
+      mockedFind
+        .mockReturnValueOnce(['a.gql'])
+        .mockReturnValueOnce(['App.tsx']);
+      mockedExtract.mockReturnValue([
+        { name: 'GetUser', type: 'query', filePath: 'a.gql', line: 1 },
+      ]);
+      mockedReadSources.mockReturnValue([
+        { file: 'App.tsx', content: 'useGetUserQuery()' },
+      ]);
+
+      mainFunction({ json: true, verbose: true });
+
+      // stdout parses as JSON on its own…
+      const report = JSON.parse(logged());
+      expect(report.summary).toEqual({
+        unusedOperations: 0,
+        unusedFragments: 0,
+      });
+      // …and the verbose detail went to stderr.
+      const errs = errorSpy.mock.calls.flat().join('\n');
+      expect(errs).toContain('"useGetUserQuery" found in App.tsx');
+    });
+
+    it('emits no verbose lines by default', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        'graphqlDir: ./g\nsrcDir: ./s\n',
+      );
+      mockedDirExists.mockReturnValue(true);
+      mockedFind
+        .mockReturnValueOnce(['a.gql'])
+        .mockReturnValueOnce(['App.tsx']);
+      mockedExtract.mockReturnValue([
+        { name: 'GetUser', type: 'query', filePath: 'a.gql' },
+      ]);
+      mockedReadSources.mockReturnValue([
+        { file: 'App.tsx', content: 'useGetUserQuery()' },
+      ]);
+
+      mainFunction();
+
+      expect(errorSpy.mock.calls.flat().join('\n')).not.toContain(
+        'found in App.tsx',
+      );
     });
 
     it('runs from CLI config when no config file exists', () => {


### PR DESCRIPTION
Closes #62

## What

Adds a `--verbose` flag that explains how the scan reached each verdict. Output (all on **stderr**):

- The resolved configuration: `graphqlDir` / `srcDir`, exclude patterns, usage patterns, fragment usage patterns
- The GraphQL files found and the number of source files scanned
- One line per operation: for **used** operations, the exact expanded pattern that matched and the file it matched in; for **unused** ones, the concrete search strings that found no match

```text
[verbose] graphqlDir: ./graphql
[verbose] srcDir: ./src
[verbose] exclude: node_modules, .git
[verbose] usagePatterns: use{Name}{Type}, use{Name}Lazy{Type}, use{Name}Suspense{Type}, {Name}Document
[verbose] fragmentUsagePatterns: {Name}FragmentDoc
[verbose] GraphQL files (1): graphql/user.gql
[verbose] Source files scanned: 42
[verbose] used:   GetUser (query) — "useGetUserQuery" found in src/App.tsx
[verbose] unused: OldQuery (query) — no match for useOldQueryQuery, useOldQueryLazyQuery, useOldQuerySuspenseQuery, OldQueryDocument
```

## Why

There was no way to see *why* gqlPrune judged an operation used or unused — which directories resolved, which concrete strings were searched, or which file matched. The per-operation "found in `<file>`" detail also makes the generated-file masking failure mode directly visible: every operation matching in the same file is the smoking gun.

## How

- `explainOperationUsage(operations, sources, usagePatterns)` — new pure function returning per-operation `{ operation, patterns, match?: { pattern, file } }`. `scanProject` now derives `unusedOperations` from this single sweep (same short-circuit order as the old `isOperationUsedInContents` path, so verdicts are identical and there's no extra scanning cost). `findUnusedOperations` remains exported and unchanged.
- `ScanResult` gains `gqlFiles` and `operationUsages` (additive).
- Pure formatters `formatVerboseConfigLines` / `formatVerboseScanLines`; `mainFunction` only wires them to `console.error`, following the existing pure-helpers pattern.
- Verbose lines are stderr-only, so `--verbose --json` keeps stdout pure JSON (verified in tests and by running the built CLI).
- Fragment-level explanations (spread-graph reachability) are intentionally out of scope for this first cut — noted in #62.

## How tested

- TDD: new failing specs first for `parseArgs`, `explainOperationUsage`, both formatters, `scanProject`'s new fields, and `mainFunction` (verbose to stderr, stdout purity with `--json`, no verbose lines by default), then the implementation.
- An `explainOperationUsage` ↔ `findUnusedOperations` agreement test pins the derived unused set to the old behavior.
- Full local gate green: `npm run build && npm run typecheck && npm run lint && npm test` (182 tests), coverage above thresholds.
- Smoke-tested the compiled CLI on a fixture project: verbose output correct, `--verbose --json` stdout parses as pure JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--verbose` option that shows resolved settings and per-operation match details.
  * Verbose details are sent to stderr, keeping standard output clean for JSON use.
  * Added clearer README guidance with an example of verbose output.

* **Bug Fixes**
  * Improved reporting so used and unused operations are explained consistently in verbose mode.

* **Tests**
  * Expanded test coverage for argument parsing, CLI behavior, and verbose output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->