### PR TITLE
feat(cli): add --help, --exclude, repeatable dirs, and strict usage errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,18 +118,19 @@ srcDir:
 Every config field has a matching flag, so you can run gqlPrune with **no `gqlPrune.config.yaml`** — handy for a one-off `npx` try with zero setup:
 
 ```bash
-npx gqlprune --graphql ./graphql --src ./src --ignore __generated__
+npx gqlprune --graphql ./graphql --src ./src --exclude __generated__
 ```
 
 | Flag | Config field |
 | ---- | ------------ |
-| `--graphql <dir>` | `graphqlDir` |
-| `--src <dir>` | `srcDir` |
-| `--ignore <folder>` _(repeatable)_ | `excludedFolders` |
+| `--graphql <dir>` _(repeatable)_ | `graphqlDir` |
+| `--src <dir>` _(repeatable)_ | `srcDir` |
+| `--exclude <glob>` _(repeatable)_ | `exclude` |
+| `--ignore <folder>` _(repeatable, deprecated — use `--exclude`)_ | `excludedFolders` |
 | `--pattern <template>` _(repeatable)_ | `usagePatterns` |
 | `--fragment-pattern <template>` _(repeatable)_ | `fragmentUsagePatterns` |
 
-Both `--flag value` and `--flag=value` work, in any order. **Precedence:** a flag overrides the same field in the YAML; flags alone work with no YAML; YAML alone works exactly as before. A list flag (e.g. `--ignore`) _replaces_ that list from the YAML rather than appending to it.
+Both `--flag value` and `--flag=value` work, in any order. **Precedence:** a flag overrides the same field in the YAML; flags alone work with no YAML; YAML alone works exactly as before. A list flag (e.g. `--exclude`) _replaces_ that list from the YAML rather than appending to it. An unknown flag, a flag missing its value, or an unknown command aborts with an error instead of being silently ignored.
 
 ## Usage
 
@@ -142,7 +143,7 @@ This prints any unused GraphQL operations and fragments. The command exits with:
 - **0** when nothing unused is found (suitable for CI gates).
 - **1** when unused operations or fragments are found (or on configuration errors).
 
-Print the installed version with `gqlprune --version` (or `-v`).
+Print the installed version with `gqlprune --version` (or `-v`), and the full list of commands and flags with `gqlprune --help` (or `-h`).
 
 ### JSON output
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,18 +1,27 @@
 #!/usr/bin/env node
 import kleur from 'kleur';
 import { generateConfig } from './core/configGenerator.js';
-import { mainFunction } from './core/gqlPruner.js';
+import { escapeAnnotationMessage, mainFunction } from './core/gqlPruner.js';
 import { formatHelp, parseArgs } from './utils/args.js';
 import { notifyUpdate } from './utils/updateNotifier.js';
 import { pkg } from './utils/pkgInfo.js';
 
 const { command, json, annotate, version, verbose, help, errors, config } =
   parseArgs(process.argv.slice(2));
+const annotateMode = annotate || process.env.GITHUB_ACTIONS === 'true';
 
-/** Prints usage errors and the --help pointer; the run is aborted. */
+/**
+ * Prints usage errors and the --help pointer; the run is aborted. In CI /
+ * --annotate mode each error is an (escaped) ::error workflow command so it
+ * surfaces in the Actions UI instead of only in the raw log.
+ */
 function reportUsageErrors(lines: string[]): void {
   for (const line of lines) {
-    console.error(kleur.red(line));
+    console.error(
+      annotateMode
+        ? `::error::${escapeAnnotationMessage(line)}`
+        : kleur.red(line),
+    );
   }
   console.error('Run "gqlprune --help" for usage.');
   process.exitCode = 1;
@@ -44,7 +53,7 @@ async function run(): Promise<void> {
   } else {
     mainFunction({
       json,
-      annotate: annotate || process.env.GITHUB_ACTIONS === 'true',
+      annotate: annotateMode,
       verbose,
       config,
     });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,17 +1,41 @@
 #!/usr/bin/env node
+import kleur from 'kleur';
 import { generateConfig } from './core/configGenerator.js';
 import { mainFunction } from './core/gqlPruner.js';
-import { parseArgs } from './utils/args.js';
+import { formatHelp, parseArgs } from './utils/args.js';
 import { notifyUpdate } from './utils/updateNotifier.js';
 import { pkg } from './utils/pkgInfo.js';
 
-const { command, json, annotate, version, verbose, config } = parseArgs(
-  process.argv.slice(2),
-);
+const { command, json, annotate, version, verbose, help, errors, config } =
+  parseArgs(process.argv.slice(2));
+
+/** Prints usage errors and the --help pointer; the run is aborted. */
+function reportUsageErrors(lines: string[]): void {
+  for (const line of lines) {
+    console.error(kleur.red(line));
+  }
+  console.error('Run "gqlprune --help" for usage.');
+  process.exitCode = 1;
+}
 
 async function run(): Promise<void> {
+  if (errors.length > 0) {
+    reportUsageErrors(errors);
+    return;
+  }
+
+  if (help) {
+    console.log(formatHelp());
+    return;
+  }
+
   if (version) {
     console.log(pkg.version);
+    return;
+  }
+
+  if (command !== undefined && command !== 'init') {
+    reportUsageErrors([`Unknown command: ${command}`]);
     return;
   }
 

--- a/src/core/gqlPruner.ts
+++ b/src/core/gqlPruner.ts
@@ -223,7 +223,7 @@ export function buildJsonReport(
 }
 
 /** Escapes a workflow-command message (data after `::`) per GitHub rules. */
-function escapeAnnotationMessage(message: string): string {
+export function escapeAnnotationMessage(message: string): string {
   return message
     .replace(/%/g, '%25')
     .replace(/\r/g, '%0D')

--- a/src/types/GqlPruneConfig.d.ts
+++ b/src/types/GqlPruneConfig.d.ts
@@ -41,6 +41,10 @@ export interface GqlPruneConfig {
 export type CliConfig = Partial<
   Pick<
     GqlPruneConfig,
-    'graphqlDir' | 'srcDir' | 'usagePatterns' | 'fragmentUsagePatterns'
+    | 'graphqlDir'
+    | 'srcDir'
+    | 'exclude'
+    | 'usagePatterns'
+    | 'fragmentUsagePatterns'
   >
 > & { excludedFolders?: string[] };

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -6,32 +6,70 @@ export type CliOptions = {
   annotate: boolean;
   version: boolean;
   verbose: boolean;
+  help: boolean;
+  /** Usage problems (unknown flag, missing value, stray argument), in order. */
+  errors: string[];
   config: CliConfig;
 };
+
+/** The usage screen printed by `--help` / `-h`. */
+export function formatHelp(): string {
+  return `gqlPrune — find unused GraphQL operations and fragments
+
+Usage:
+  gqlprune [command] [flags]
+
+Commands:
+  init                      Create gqlPrune.config.yaml interactively
+
+Flags:
+  --graphql <dir>           Directory with .gql/.graphql files (repeatable)
+  --src <dir>               Directory with source files (repeatable)
+  --exclude <glob>          Files/folders to skip; gitignore-style globs (repeatable)
+  --ignore <folder>         Deprecated: use --exclude instead
+  --pattern <template>      Operation usage pattern, e.g. use{Name}{Type} (repeatable)
+  --fragment-pattern <t>    Fragment usage pattern, e.g. {Name}FragmentDoc (repeatable)
+  --json                    Print a machine-readable JSON report on stdout
+  --annotate                Emit GitHub Actions ::warning annotations (auto in Actions)
+  --verbose                 Explain each verdict on stderr
+  -v, --version             Print the installed version
+  -h, --help                Show this help
+
+Flags accept both "--flag value" and "--flag=value" and override the matching
+field in gqlPrune.config.yaml.
+Docs: https://github.com/Krister-Johansson/gqlPrune#readme`;
+}
 
 /**
  * Parses CLI arguments (everything after the node binary and script path).
  *
  * Recognizes the optional `init` command, the boolean `--json` / `--annotate`
- * / `--verbose` flags, and value flags that mirror the config file:
- * `--graphql`, `--src`, and the repeatable `--ignore`, `--pattern`,
+ * / `--verbose` / `--help` flags, and value flags that mirror the config file:
+ * the repeatable `--graphql`, `--src`, `--exclude`, `--ignore`, `--pattern`,
  * `--fragment-pattern`. Value flags accept both `--flag value` and
  * `--flag=value`, in any order. A value is never mistaken for the positional
- * command.
+ * command. Unknown flags, flags missing their value, and stray positional
+ * arguments are collected into `errors` rather than silently dropped — the
+ * caller decides how to report them.
  *
  * @param {string[]} argv - Arguments, e.g. `process.argv.slice(2)`.
  * @returns {CliOptions} - The resolved command, flags, and CLI config overrides.
  */
 export function parseArgs(argv: string[]): CliOptions {
   const config: CliConfig = {};
+  const graphqlDirs: string[] = [];
+  const srcDirs: string[] = [];
+  const exclude: string[] = [];
   const excludedFolders: string[] = [];
   const usagePatterns: string[] = [];
   const fragmentUsagePatterns: string[] = [];
+  const errors: string[] = [];
   let command: string | undefined;
   let json = false;
   let annotate = false;
   let version = false;
   let verbose = false;
+  let help = false;
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -48,14 +86,18 @@ export function parseArgs(argv: string[]): CliOptions {
     }
 
     // The flag's value: the inline `=value`, else the next arg when it isn't
-    // itself a flag (so a value is never consumed as the command).
+    // itself a flag (so a value is never consumed as the command). A flag
+    // without a value is a usage error, not a silent no-op.
     const takeValue = (): string | undefined => {
-      if (inlineValue !== undefined) return inlineValue;
-      const next = argv[i + 1];
-      if (next !== undefined && !next.startsWith('-')) {
-        i += 1;
-        return next;
+      if (inlineValue !== undefined && inlineValue !== '') return inlineValue;
+      if (inlineValue === undefined) {
+        const next = argv[i + 1];
+        if (next !== undefined && !next.startsWith('-')) {
+          i += 1;
+          return next;
+        }
       }
+      errors.push(`Missing value for ${name}`);
       return undefined;
     };
 
@@ -73,14 +115,23 @@ export function parseArgs(argv: string[]): CliOptions {
       case '-v':
         version = true;
         break;
+      case '--help':
+      case '-h':
+        help = true;
+        break;
       case '--graphql': {
         const value = takeValue();
-        if (value !== undefined) config.graphqlDir = value;
+        if (value !== undefined) graphqlDirs.push(value);
         break;
       }
       case '--src': {
         const value = takeValue();
-        if (value !== undefined) config.srcDir = value;
+        if (value !== undefined) srcDirs.push(value);
+        break;
+      }
+      case '--exclude': {
+        const value = takeValue();
+        if (value !== undefined) exclude.push(value);
         break;
       }
       case '--ignore': {
@@ -99,15 +150,30 @@ export function parseArgs(argv: string[]): CliOptions {
         break;
       }
       default:
-        if (!arg.startsWith('-') && command === undefined) command = arg;
+        if (arg.startsWith('-')) {
+          errors.push(`Unknown flag: ${name}`);
+        } else if (command === undefined) {
+          command = arg;
+        } else {
+          errors.push(`Unexpected argument: ${arg}`);
+        }
     }
   }
 
+  // A single value keeps the plain-string shape; repeats become an array,
+  // matching the config schema (`string | string[]`).
+  if (graphqlDirs.length > 0) {
+    config.graphqlDir = graphqlDirs.length === 1 ? graphqlDirs[0] : graphqlDirs;
+  }
+  if (srcDirs.length > 0) {
+    config.srcDir = srcDirs.length === 1 ? srcDirs[0] : srcDirs;
+  }
+  if (exclude.length > 0) config.exclude = exclude;
   if (excludedFolders.length > 0) config.excludedFolders = excludedFolders;
   if (usagePatterns.length > 0) config.usagePatterns = usagePatterns;
   if (fragmentUsagePatterns.length > 0) {
     config.fragmentUsagePatterns = fragmentUsagePatterns;
   }
 
-  return { command, json, annotate, version, verbose, config };
+  return { command, json, annotate, version, verbose, help, errors, config };
 }

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -1,4 +1,4 @@
-import { parseArgs } from '../src/utils/args';
+import { formatHelp, parseArgs } from '../src/utils/args';
 
 describe('parseArgs', () => {
   it('defaults to no command, all flags false, empty config', () => {
@@ -8,6 +8,8 @@ describe('parseArgs', () => {
       annotate: false,
       version: false,
       verbose: false,
+      help: false,
+      errors: [],
       config: {},
     });
   });
@@ -19,6 +21,8 @@ describe('parseArgs', () => {
       annotate: false,
       version: false,
       verbose: false,
+      help: false,
+      errors: [],
       config: {},
     });
   });
@@ -30,6 +34,8 @@ describe('parseArgs', () => {
       annotate: false,
       version: false,
       verbose: false,
+      help: false,
+      errors: [],
       config: {},
     });
   });
@@ -41,6 +47,8 @@ describe('parseArgs', () => {
       annotate: true,
       version: false,
       verbose: false,
+      help: false,
+      errors: [],
       config: {},
     });
   });
@@ -52,6 +60,8 @@ describe('parseArgs', () => {
       annotate: false,
       version: false,
       verbose: true,
+      help: false,
+      errors: [],
       config: {},
     });
   });
@@ -75,6 +85,8 @@ describe('parseArgs', () => {
       annotate: true,
       version: false,
       verbose: false,
+      help: false,
+      errors: [],
       config: {},
     });
   });
@@ -134,14 +146,112 @@ describe('parseArgs', () => {
       annotate: false,
       version: false,
       verbose: false,
+      help: false,
+      errors: [],
       config: { graphqlDir: './g', srcDir: './s', excludedFolders: ['x'] },
     });
   });
 
-  it('ignores a value flag given no value', () => {
-    // `--graphql` with no following value (the next token is another flag).
+  it('reports a missing value when the next token is another flag', () => {
     const result = parseArgs(['--graphql', '--json']);
     expect(result.config).toEqual({});
+    expect(result.errors).toEqual(['Missing value for --graphql']);
     expect(result.json).toBe(true);
+  });
+
+  it('reports a missing value at the end of the arguments', () => {
+    expect(parseArgs(['--src']).errors).toEqual(['Missing value for --src']);
+  });
+
+  it('reports an empty inline value as missing', () => {
+    expect(parseArgs(['--graphql=']).errors).toEqual([
+      'Missing value for --graphql',
+    ]);
+  });
+
+  it('parses --help and the -h short flag', () => {
+    expect(parseArgs(['--help']).help).toBe(true);
+    expect(parseArgs(['-h']).help).toBe(true);
+    expect(parseArgs([]).help).toBe(false);
+  });
+
+  it('reports an unknown flag as an error', () => {
+    expect(parseArgs(['--jsn']).errors).toEqual(['Unknown flag: --jsn']);
+  });
+
+  it('reports an unknown flag given in --flag=value form', () => {
+    expect(parseArgs(['--foo=bar']).errors).toEqual(['Unknown flag: --foo']);
+  });
+
+  it('reports an unknown short flag as an error', () => {
+    expect(parseArgs(['-x']).errors).toEqual(['Unknown flag: -x']);
+  });
+
+  it('reports an unexpected second positional argument', () => {
+    const result = parseArgs(['init', 'extra']);
+    expect(result.command).toBe('init');
+    expect(result.errors).toEqual(['Unexpected argument: extra']);
+  });
+
+  it('collects repeated --graphql and --src into arrays', () => {
+    expect(
+      parseArgs([
+        '--graphql',
+        './g1',
+        '--graphql',
+        './g2',
+        '--src',
+        './s1',
+        '--src',
+        './s2',
+      ]).config,
+    ).toEqual({ graphqlDir: ['./g1', './g2'], srcDir: ['./s1', './s2'] });
+  });
+
+  it('keeps a single --graphql / --src value as a string', () => {
+    expect(parseArgs(['--graphql', './g', '--src', './s']).config).toEqual({
+      graphqlDir: './g',
+      srcDir: './s',
+    });
+  });
+
+  it('collects repeatable --exclude into config.exclude', () => {
+    expect(
+      parseArgs([
+        '--exclude',
+        '**/*.generated.ts',
+        '--exclude',
+        '__generated__',
+      ]).config,
+    ).toEqual({ exclude: ['**/*.generated.ts', '__generated__'] });
+  });
+});
+
+describe('formatHelp', () => {
+  it('documents the command and every flag', () => {
+    const help = formatHelp();
+    expect(help).toContain('init');
+    for (const flag of [
+      '--graphql',
+      '--src',
+      '--exclude',
+      '--ignore',
+      '--pattern',
+      '--fragment-pattern',
+      '--json',
+      '--annotate',
+      '--verbose',
+      '--version',
+      '--help',
+    ]) {
+      expect(help).toContain(flag);
+    }
+  });
+
+  it('marks --ignore as deprecated in favor of --exclude', () => {
+    const line = formatHelp()
+      .split('\n')
+      .find((l) => l.includes('--ignore'));
+    expect(line).toMatch(/deprecated/i);
   });
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -31,7 +31,11 @@ describe('cli dispatch', () => {
       jest.doMock('../src/core/configGenerator', () => ({
         generateConfig: jest.fn(),
       }));
-      jest.doMock('../src/core/gqlPruner', () => ({ mainFunction: jest.fn() }));
+      // Partial mock: cli.ts also imports the real escapeAnnotationMessage.
+      jest.doMock('../src/core/gqlPruner', () => ({
+        ...jest.requireActual('../src/core/gqlPruner'),
+        mainFunction: jest.fn(),
+      }));
       jest.doMock('../src/utils/updateNotifier', () => ({
         notifyUpdate: jest.fn(),
       }));
@@ -180,6 +184,42 @@ describe('cli dispatch', () => {
     );
     expect(mainFunction).not.toHaveBeenCalled();
     expect(process.exitCode).toBe(1);
+    errorSpy.mockRestore();
+  });
+
+  it('emits usage errors as ::error annotations in --annotate mode', () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const { mainFunction } = runCli(['--jsn', '--annotate']);
+    expect(errorSpy.mock.calls.flat().join('\n')).toContain(
+      '::error::Unknown flag: --jsn',
+    );
+    expect(mainFunction).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    errorSpy.mockRestore();
+  });
+
+  it('emits usage errors as ::error annotations under GitHub Actions', () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    runCli(['--jsn'], { GITHUB_ACTIONS: 'true' });
+    expect(errorSpy.mock.calls.flat().join('\n')).toContain(
+      '::error::Unknown flag: --jsn',
+    );
+    errorSpy.mockRestore();
+  });
+
+  it('escapes usage-error annotations per workflow-command rules', () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    // A stray flag containing "%" must be %25-escaped inside ::error data.
+    runCli(['--50%off', '--annotate']);
+    expect(errorSpy.mock.calls.flat().join('\n')).toContain(
+      '::error::Unknown flag: --50%25off',
+    );
     errorSpy.mockRestore();
   });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -13,6 +13,7 @@ describe('cli dispatch', () => {
       process.env.GITHUB_ACTIONS = realGHA;
     }
     jest.resetModules();
+    process.exitCode = 0; // error paths set exitCode; don't leak to the runner
   });
 
   function runCli(args: string[], env: { GITHUB_ACTIONS?: string } = {}) {
@@ -140,5 +141,59 @@ describe('cli dispatch', () => {
       verbose: false,
       config: { graphqlDir: './g', srcDir: './s' },
     });
+  });
+
+  it('prints usage and exits without running the pruner on --help', () => {
+    const logSpy = jest
+      .spyOn(console, 'log')
+      .mockImplementation(() => undefined);
+    const { mainFunction, generateConfig, notifyUpdate } = runCli(['--help']);
+    expect(logSpy.mock.calls.flat().join('\n')).toContain('Usage:');
+    expect(mainFunction).not.toHaveBeenCalled();
+    expect(generateConfig).not.toHaveBeenCalled();
+    expect(notifyUpdate).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(0);
+    logSpy.mockRestore();
+  });
+
+  it('reports an unknown flag on stderr and does not run', () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const { mainFunction, notifyUpdate } = runCli(['--jsn']);
+    const errs = errorSpy.mock.calls.flat().join('\n');
+    expect(errs).toContain('Unknown flag: --jsn');
+    expect(errs).toContain('--help');
+    expect(mainFunction).not.toHaveBeenCalled();
+    expect(notifyUpdate).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    errorSpy.mockRestore();
+  });
+
+  it('reports a missing flag value on stderr and does not run', () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const { mainFunction } = runCli(['--graphql']);
+    expect(errorSpy.mock.calls.flat().join('\n')).toContain(
+      'Missing value for --graphql',
+    );
+    expect(mainFunction).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    errorSpy.mockRestore();
+  });
+
+  it('rejects an unknown command', () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const { mainFunction, generateConfig } = runCli(['scna']);
+    const errs = errorSpy.mock.calls.flat().join('\n');
+    expect(errs).toContain('Unknown command: scna');
+    expect(errs).toContain('--help');
+    expect(mainFunction).not.toHaveBeenCalled();
+    expect(generateConfig).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    errorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Closes #65

## What

Four CLI ergonomics fixes from the code-review backlog, all in the argument-parsing layer:

1. **`--help` / `-h`** — prints a usage screen (command, all flags, placeholder syntax, precedence note) to stdout and exits 0.
2. **Strict usage errors** — an unknown flag (`--jsn`), a value flag missing its value (`gqlprune --graphql`), an unexpected extra positional, or an unknown command (`gqlprune scna`) now aborts with a red stderr error plus a `--help` pointer and exit code 1. Previously all of these were silently dropped, and the user hit the unrelated "No configuration found" error.
3. **Repeatable `--graphql` / `--src`** — collected into arrays, matching the `string | string[]` config schema. A single value keeps its plain-string shape, so the existing behavior is unchanged for current invocations.
4. **`--exclude <glob>`** (repeatable) — maps to the unified `exclude` config field introduced in v2.9. `--ignore` keeps working (it maps to the deprecated `excludedFolders`) but is documented as deprecated in favor of `--exclude` in both the help screen and README.

```text
$ gqlprune --jsn
Unknown flag: --jsn
Run "gqlprune --help" for usage.
```

## How

- `parseArgs` collects problems into a new `errors: string[]` on `CliOptions` rather than reporting them itself, keeping it pure; `cli.ts` decides how to present them. An empty inline value (`--graphql=`) also counts as missing.
- `formatHelp()` is a pure exported function in `args.ts`; `cli.ts` only prints it.
- `CliConfig` gains `'exclude'` in its `Pick` (additive).
- Dispatch order in `cli.ts`: usage errors → help → version → unknown command → init/scan, so errors always win and `--help` never runs a scan.

## How tested

- TDD: failing specs first — 15 new tests across `parseArgs` (help flags, each error class, repeatable dirs keeping single-value string shape, `--exclude`), `formatHelp` (documents every flag, marks `--ignore` deprecated), and the cli dispatch (help exits 0 without running the pruner or update check; each error path exits 1 without running anything).
- Full local gate green: `npm run build && npm run typecheck && npm run lint && npm test` (198 tests), coverage above thresholds.
- Smoke-tested the compiled CLI: `--help` screen, unknown flag / missing value / unknown command all exit 1 with the right stderr, and `--exclude` + repeated `--src` produce the expected scan results on a fixture project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--help`/`-h` support with formatted usage output, plus `--version` handling.
  * Added support for `--exclude`, and improved repeatable `--graphql`/`--src` parsing.

* **Bug Fixes**
  * Unknown commands, unknown flags, and missing flag values now fail fast with clear errors (including annotated errors in annotate/workflow modes) and a non-zero exit code.

* **Documentation**
  * Updated CLI documentation to reflect `--exclude`, mark `--ignore` as deprecated, and document stricter precedence/error behavior.

* **Tests**
  * Expanded CLI and argument parsing coverage for help, errors, and repeatable flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->