### PR TITLE
refactor(scan): parse each GraphQL file once; drop dead fileUtils helpers

### DIFF
--- a/src/core/gqlPruner.ts
+++ b/src/core/gqlPruner.ts
@@ -18,7 +18,7 @@ import {
   DEFAULT_FRAGMENT_USAGE_PATTERNS,
   DEFAULT_USAGE_PATTERNS,
 } from '../utils/usagePatterns.js';
-import { extractOperations } from '../utils/operations.js';
+import { extractGraphqlEntities } from '../utils/operations.js';
 import { findUnusedFragmentsInCorpus } from '../utils/fragments.js';
 
 // Folders that are always excluded from traversal, regardless of config.
@@ -512,7 +512,11 @@ export function scanProject(config: GqlPruneConfig): ScanResult {
       ),
     ),
   ];
-  const operations: OperationInfo[] = gqlFiles.flatMap(extractOperations);
+  // Parse every gql file once; operations and the fragment scan share the result.
+  const parsedFiles = gqlFiles.map(extractGraphqlEntities);
+  const operations: OperationInfo[] = parsedFiles.flatMap(
+    (file) => file.operations,
+  );
 
   const tsFiles = [
     ...new Set(
@@ -537,7 +541,7 @@ export function scanProject(config: GqlPruneConfig): ScanResult {
     .filter((usage) => !usage.match)
     .map((usage) => usage.operation);
   const unusedFragments = findUnusedFragmentsInCorpus(
-    gqlFiles,
+    parsedFiles,
     fileContents,
     fragmentUsagePatterns,
   );

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -127,16 +127,6 @@ export function readSourceFiles(filePaths: string[]): SourceFile[] {
 }
 
 /**
- * Reads the contents of multiple files once, skipping any that cannot be read.
- *
- * @param {string[]} filePaths - The files to read.
- * @returns {string[]} - The contents of the readable files.
- */
-export function readFileContents(filePaths: string[]): string[] {
-  return readSourceFiles(filePaths).map((source) => source.content);
-}
-
-/**
  * Checks whether any of the given patterns appears in any of the provided file
  * contents. Operating on already-read contents avoids re-reading every source
  * file once per operation.
@@ -152,28 +142,6 @@ export function isOperationUsedInContents(
   return contents.some((content) =>
     patterns.some((pattern) => content.includes(pattern)),
   );
-}
-
-/**
- * Checks if a specific operation is used within a file.
- *
- * @param {string} operation - The operation to search for.
- * @param {string} filePath - The path to the file to search within.
- * @returns {boolean} - Returns true if the operation is found in the file, otherwise false.
- */
-export function isOperationUsed(operation: string, filePath: string): boolean {
-  try {
-    const content = fs.readFileSync(filePath, 'utf-8');
-    return content.includes(operation);
-  } catch (error) {
-    console.error(`Error reading file: ${filePath}`);
-    if (error instanceof Error) {
-      console.error(error.message);
-    } else {
-      console.error(error);
-    }
-    return false;
-  }
 }
 
 /**

--- a/src/utils/fragments.ts
+++ b/src/utils/fragments.ts
@@ -1,5 +1,5 @@
 import { FragmentInfo } from '../types/FragmentInfo.js';
-import { extractGraphqlEntities } from './operations.js';
+import { GraphqlFileEntities } from './operations.js';
 import { isOperationUsedInContents } from './fileUtils.js';
 import {
   buildFragmentPatterns,
@@ -51,23 +51,25 @@ export function findUnusedFragments(
 }
 
 /**
- * Scans the GraphQL corpus and returns fragments that are unused — i.e. neither
- * (a) reachable via fragment spreads from any operation, nor (b) referenced in
- * the application source (e.g. a `<Name>FragmentDoc` constant under fragment
- * masking). Schema-free.
+ * Walks the parsed GraphQL corpus and returns fragments that are unused — i.e.
+ * neither (a) reachable via fragment spreads from any operation, nor (b)
+ * referenced in the application source (e.g. a `<Name>FragmentDoc` constant
+ * under fragment masking). Operates on pre-parsed entities (see
+ * `extractGraphqlEntities`) so each file is parsed once per scan; this function
+ * never touches the filesystem. Schema-free.
  *
  * Note: a fragment is considered used as soon as any operation spreads it, even
  * if that operation is itself unused — that operation is reported separately, so
  * this avoids flagging a fragment that becomes orphaned only after the operation
  * is deleted (caught on the next run).
  *
- * @param {string[]} gqlFiles - The `.gql`/`.graphql` files to analyze.
+ * @param {GraphqlFileEntities[]} parsedFiles - One parsed entry per gql file.
  * @param {string[]} fileContents - The already-read source file contents.
  * @param {string[]} fragmentUsagePatterns - Templates for source references.
  * @returns {FragmentInfo[]} - The unused fragments across the corpus.
  */
 export function findUnusedFragmentsInCorpus(
-  gqlFiles: string[],
+  parsedFiles: GraphqlFileEntities[],
   fileContents: string[],
   fragmentUsagePatterns: string[] = DEFAULT_FRAGMENT_USAGE_PATTERNS,
 ): FragmentInfo[] {
@@ -76,8 +78,7 @@ export function findUnusedFragmentsInCorpus(
   const roots = new Set<string>();
   const seenFragmentNames = new Set<string>();
 
-  for (const file of gqlFiles) {
-    const entities = extractGraphqlEntities(file);
+  for (const entities of parsedFiles) {
     entities.operationSpreads.forEach((spread) => roots.add(spread));
     for (const fragment of entities.fragments) {
       // Fragment names should be unique across the corpus. If they aren't, the

--- a/src/utils/operations.ts
+++ b/src/utils/operations.ts
@@ -92,13 +92,3 @@ export function extractGraphqlEntities(filePath: string): GraphqlFileEntities {
     };
   }
 }
-
-/**
- * Extracts GraphQL operations (queries, mutations, subscriptions) from a file.
- *
- * @param {string} filePath - The path to the GraphQL file.
- * @returns {OperationInfo[]} - The named operations defined in the file.
- */
-export function extractOperations(filePath: string): OperationInfo[] {
-  return extractGraphqlEntities(filePath).operations;
-}

--- a/test/fileUtils.test.ts
+++ b/test/fileUtils.test.ts
@@ -3,9 +3,7 @@ import {
   createExcludeMatcher,
   directoryExists,
   findFilesWithExtension,
-  isOperationUsed,
   isOperationUsedInContents,
-  readFileContents,
   readSourceFiles,
 } from '../src/utils/fileUtils';
 import { buildUsagePatterns } from '../src/utils/usagePatterns';
@@ -120,25 +118,6 @@ describe('fileUtils', () => {
     });
   });
 
-  describe('isOperationUsed', () => {
-    it('should check if an operation is used in a file', () => {
-      (fs.readFileSync as jest.Mock).mockReturnValue(
-        'const result = useMyQuery();',
-      );
-      expect(isOperationUsed('useMyQuery', './file.ts')).toBe(true);
-      expect(isOperationUsed('useAnotherQuery', './file.ts')).toBe(false);
-    });
-
-    it('should handle error when reading a file', () => {
-      (fs.readFileSync as jest.Mock).mockImplementation(() => {
-        throw new Error('Failed to read file');
-      });
-
-      const result = isOperationUsed('someOperation', './file1.ts');
-      expect(result).toBe(false); // Expect false since the file read failed
-    });
-  });
-
   describe('directoryExists', () => {
     afterEach(() => {
       jest.resetAllMocks();
@@ -217,30 +196,6 @@ describe('fileUtils', () => {
     it('excludes nothing when there are no positive patterns', () => {
       expect(createExcludeMatcher([])('anything')).toBe(false);
       expect(createExcludeMatcher(['  ', '!only-neg'])('anything')).toBe(false);
-    });
-  });
-
-  describe('readFileContents', () => {
-    it('should read each file once and return their contents', () => {
-      (fs.readFileSync as jest.Mock)
-        .mockReturnValueOnce('content-a')
-        .mockReturnValueOnce('content-b');
-
-      expect(readFileContents(['a.ts', 'b.ts'])).toEqual([
-        'content-a',
-        'content-b',
-      ]);
-      expect(fs.readFileSync).toHaveBeenCalledTimes(2);
-    });
-
-    it('should skip files that cannot be read', () => {
-      (fs.readFileSync as jest.Mock)
-        .mockImplementationOnce(() => {
-          throw new Error('nope');
-        })
-        .mockReturnValueOnce('content-b');
-
-      expect(readFileContents(['bad.ts', 'b.ts'])).toEqual(['content-b']);
     });
   });
 

--- a/test/fragments.test.ts
+++ b/test/fragments.test.ts
@@ -4,6 +4,7 @@ import {
   findUnusedFragmentsInCorpus,
   reachableFragments,
 } from '../src/utils/fragments';
+import { extractGraphqlEntities } from '../src/utils/operations';
 import { FragmentInfo } from '../src/types/FragmentInfo';
 
 jest.mock('fs');
@@ -98,7 +99,7 @@ describe('fragments', () => {
         return 'fragment Used on T { id }\nfragment Dead on T { id }';
       });
       const unused = findUnusedFragmentsInCorpus(
-        ['ops.gql', 'frags.gql'],
+        ['ops.gql', 'frags.gql'].map(extractGraphqlEntities),
         [],
         ['{Name}FragmentDoc'],
       );
@@ -110,7 +111,7 @@ describe('fragments', () => {
         'fragment Masked on T { id }',
       );
       const unused = findUnusedFragmentsInCorpus(
-        ['f.gql'],
+        ['f.gql'].map(extractGraphqlEntities),
         ['const x = MaskedFragmentDoc;'],
         ['{Name}FragmentDoc'],
       );
@@ -123,7 +124,7 @@ describe('fragments', () => {
         return 'fragment Outer on T { ...Inner }\nfragment Inner on T { id }\nfragment Lonely on T { id }';
       });
       const unused = findUnusedFragmentsInCorpus(
-        ['ops.gql', 'frags.gql'],
+        ['ops.gql', 'frags.gql'].map(extractGraphqlEntities),
         [],
         ['{Name}FragmentDoc'],
       );
@@ -132,7 +133,13 @@ describe('fragments', () => {
 
     it('returns [] when there are no fragments', () => {
       (fs.readFileSync as jest.Mock).mockReturnValue('query Q { id }');
-      expect(findUnusedFragmentsInCorpus(['ops.gql'], [], [])).toEqual([]);
+      expect(
+        findUnusedFragmentsInCorpus(
+          ['ops.gql'].map(extractGraphqlEntities),
+          [],
+          [],
+        ),
+      ).toEqual([]);
     });
 
     it('warns on duplicate fragment names and merges their spread edges', () => {
@@ -148,7 +155,7 @@ describe('fragments', () => {
       (console.warn as jest.Mock).mockClear();
 
       const unused = findUnusedFragmentsInCorpus(
-        ['a.gql', 'b.gql'],
+        ['a.gql', 'b.gql'].map(extractGraphqlEntities),
         [],
         ['{Name}FragmentDoc'],
       );

--- a/test/gqlPruner.test.ts
+++ b/test/gqlPruner.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as fileUtils from '../src/utils/fileUtils';
-import { extractOperations } from '../src/utils/operations';
+import { extractGraphqlEntities } from '../src/utils/operations';
 import * as fragments from '../src/utils/fragments';
 import {
   buildJsonReport,
@@ -39,7 +39,7 @@ jest.mock('../src/utils/fileUtils', () => {
   };
 });
 jest.mock('../src/utils/operations', () => ({
-  extractOperations: jest.fn(),
+  extractGraphqlEntities: jest.fn(),
 }));
 jest.mock('../src/utils/fragments', () => ({
   findUnusedFragmentsInCorpus: jest.fn(() => []),
@@ -48,7 +48,16 @@ jest.mock('../src/utils/fragments', () => ({
 const mockedDirExists = fileUtils.directoryExists as jest.Mock;
 const mockedFind = fileUtils.findFilesWithExtension as jest.Mock;
 const mockedReadSources = fileUtils.readSourceFiles as jest.Mock;
-const mockedExtract = extractOperations as jest.Mock;
+const mockedExtract = extractGraphqlEntities as jest.Mock;
+
+// The parsed-file shape extractGraphqlEntities returns for a file whose only
+// contents are the given operations.
+const entitiesOf = (operations: OperationInfo[]) => ({
+  operations,
+  fragments: [],
+  operationSpreads: [],
+  fragmentSpreads: [],
+});
 const mockedUnusedFragments =
   fragments.findUnusedFragmentsInCorpus as jest.Mock;
 
@@ -624,7 +633,7 @@ describe('gqlPruner', () => {
         .mockReturnValueOnce(['a.gql']) // graphqlDir[0]
         .mockReturnValueOnce(['a.gql', 'b.gql']) // graphqlDir[1] (a.gql overlaps)
         .mockReturnValueOnce(['App.tsx']); // srcDir
-      mockedExtract.mockReturnValue([]);
+      mockedExtract.mockReturnValue(entitiesOf([]));
       mockedReadSources.mockReturnValue([{ file: 'App.tsx', content: '' }]);
 
       const result = scanProject({ graphqlDir: ['g1', 'g2'], srcDir: 's' });
@@ -637,10 +646,12 @@ describe('gqlPruner', () => {
       mockedFind
         .mockReturnValueOnce(['a.gql']) // gql files
         .mockReturnValueOnce(['App.tsx']); // source files
-      mockedExtract.mockReturnValue([
-        { name: 'GetUser', type: 'query', filePath: 'a.gql' },
-        { name: 'Unused', type: 'query', filePath: 'a.gql' },
-      ]);
+      mockedExtract.mockReturnValue(
+        entitiesOf([
+          { name: 'GetUser', type: 'query', filePath: 'a.gql' },
+          { name: 'Unused', type: 'query', filePath: 'a.gql' },
+        ]),
+      );
       mockedReadSources.mockReturnValue([
         { file: 'App.tsx', content: 'useGetUserQuery()' },
       ]);
@@ -656,14 +667,33 @@ describe('gqlPruner', () => {
       expect(result.generatedFiles).toEqual([]);
     });
 
+    it('parses each GraphQL file exactly once and shares the result with the fragment scan', () => {
+      mockedFind
+        .mockReturnValueOnce(['a.gql', 'b.gql']) // gql files
+        .mockReturnValueOnce(['App.tsx']); // source files
+      mockedExtract.mockReturnValue(entitiesOf([]));
+      mockedReadSources.mockReturnValue([{ file: 'App.tsx', content: '' }]);
+
+      scanProject({ graphqlDir: './g', srcDir: './s' });
+
+      expect(mockedExtract).toHaveBeenCalledTimes(2);
+      expect(mockedUnusedFragments).toHaveBeenCalledWith(
+        [entitiesOf([]), entitiesOf([])],
+        [''],
+        DEFAULT_FRAGMENT_USAGE_PATTERNS,
+      );
+    });
+
     it('exposes the scanned gql files and a usage explanation per operation', () => {
       mockedFind
         .mockReturnValueOnce(['a.gql']) // gql files
         .mockReturnValueOnce(['App.tsx']); // source files
-      mockedExtract.mockReturnValue([
-        { name: 'GetUser', type: 'query', filePath: 'a.gql' },
-        { name: 'Unused', type: 'query', filePath: 'a.gql' },
-      ]);
+      mockedExtract.mockReturnValue(
+        entitiesOf([
+          { name: 'GetUser', type: 'query', filePath: 'a.gql' },
+          { name: 'Unused', type: 'query', filePath: 'a.gql' },
+        ]),
+      );
       mockedReadSources.mockReturnValue([
         { file: 'App.tsx', content: 'useGetUserQuery()' },
       ]);
@@ -688,7 +718,7 @@ describe('gqlPruner', () => {
       mockedFind
         .mockReturnValueOnce(['a.gql']) // gql files
         .mockReturnValueOnce(['graphql.ts']); // source files
-      mockedExtract.mockReturnValue(ops);
+      mockedExtract.mockReturnValue(entitiesOf(ops));
       // One file references every operation (via {Name}Document) → coverage 1.0.
       mockedReadSources.mockReturnValue([
         {
@@ -772,10 +802,12 @@ describe('gqlPruner', () => {
       mockedFind
         .mockReturnValueOnce(['a.gql']) // gql files
         .mockReturnValueOnce(['App.tsx']); // source files
-      mockedExtract.mockReturnValue([
-        { name: 'GetUser', type: 'query', filePath: 'a.gql' },
-        { name: 'Unused', type: 'query', filePath: 'a.gql' },
-      ]);
+      mockedExtract.mockReturnValue(
+        entitiesOf([
+          { name: 'GetUser', type: 'query', filePath: 'a.gql' },
+          { name: 'Unused', type: 'query', filePath: 'a.gql' },
+        ]),
+      );
       mockedReadSources.mockReturnValue([
         { file: 'App.tsx', content: 'const r = useGetUserQuery()' },
       ]);
@@ -794,9 +826,9 @@ describe('gqlPruner', () => {
       mockedFind
         .mockReturnValueOnce(['a.gql'])
         .mockReturnValueOnce(['App.tsx']);
-      mockedExtract.mockReturnValue([
-        { name: 'GetUser', type: 'query', filePath: 'a.gql' },
-      ]);
+      mockedExtract.mockReturnValue(
+        entitiesOf([{ name: 'GetUser', type: 'query', filePath: 'a.gql' }]),
+      );
       mockedReadSources.mockReturnValue([
         { file: 'App.tsx', content: 'useGetUserQuery()' },
       ]);
@@ -814,7 +846,7 @@ describe('gqlPruner', () => {
       mockedFind
         .mockReturnValueOnce(['a.gql'])
         .mockReturnValueOnce(['App.tsx']);
-      mockedExtract.mockReturnValue([]); // no operations at all
+      mockedExtract.mockReturnValue(entitiesOf([])); // no operations at all
       mockedReadSources.mockReturnValue([{ file: 'App.tsx', content: '' }]);
       mockedUnusedFragments.mockReturnValueOnce([
         { name: 'DeadFragment', filePath: 'a.gql' },
@@ -834,14 +866,14 @@ describe('gqlPruner', () => {
       mockedFind
         .mockReturnValueOnce(['a.gql'])
         .mockReturnValueOnce(['App.tsx']);
-      mockedExtract.mockReturnValue([]);
+      mockedExtract.mockReturnValue(entitiesOf([]));
       mockedReadSources.mockReturnValue([
         { file: 'App.tsx', content: 'source' },
       ]);
 
       expect(() => mainFunction()).not.toThrow();
       expect(mockedUnusedFragments).toHaveBeenCalledWith(
-        ['a.gql'],
+        [entitiesOf([])],
         ['source'],
         ['{Name}FragmentDoc'],
       );
@@ -855,10 +887,12 @@ describe('gqlPruner', () => {
       mockedFind
         .mockReturnValueOnce(['a.gql'])
         .mockReturnValueOnce(['App.tsx']);
-      mockedExtract.mockReturnValue([
-        { name: 'GetUser', type: 'query', filePath: 'a.gql', line: 1 },
-        { name: 'Unused', type: 'query', filePath: 'a.gql', line: 2 },
-      ]);
+      mockedExtract.mockReturnValue(
+        entitiesOf([
+          { name: 'GetUser', type: 'query', filePath: 'a.gql', line: 1 },
+          { name: 'Unused', type: 'query', filePath: 'a.gql', line: 2 },
+        ]),
+      );
       mockedReadSources.mockReturnValue([
         { file: 'App.tsx', content: 'useGetUserQuery()' },
       ]);
@@ -891,9 +925,11 @@ describe('gqlPruner', () => {
       mockedFind
         .mockReturnValueOnce(['a.gql'])
         .mockReturnValueOnce(['App.tsx']);
-      mockedExtract.mockReturnValue([
-        { name: 'GetUser', type: 'query', filePath: 'a.gql', line: 1 },
-      ]);
+      mockedExtract.mockReturnValue(
+        entitiesOf([
+          { name: 'GetUser', type: 'query', filePath: 'a.gql', line: 1 },
+        ]),
+      );
       mockedReadSources.mockReturnValue([
         { file: 'App.tsx', content: 'useGetUserQuery()' },
       ]);
@@ -915,9 +951,11 @@ describe('gqlPruner', () => {
       mockedFind
         .mockReturnValueOnce(['a.gql'])
         .mockReturnValueOnce(['App.tsx']);
-      mockedExtract.mockReturnValue([
-        { name: 'Dead', type: 'query', filePath: 'a.gql', line: 4 },
-      ]);
+      mockedExtract.mockReturnValue(
+        entitiesOf([
+          { name: 'Dead', type: 'query', filePath: 'a.gql', line: 4 },
+        ]),
+      );
       mockedReadSources.mockReturnValue([{ file: 'App.tsx', content: '' }]);
 
       mainFunction({ annotate: true });
@@ -935,14 +973,14 @@ describe('gqlPruner', () => {
       mockedDirExists.mockReturnValue(true);
       const ops = ['A', 'B', 'C', 'D', 'E'].map((name) => ({
         name,
-        type: 'query',
+        type: 'query' as const,
         filePath: 'a.gql',
         line: 1,
       }));
       mockedFind
         .mockReturnValueOnce(['a.gql']) // gql files
         .mockReturnValueOnce(['src/gql/graphql.ts']); // source files
-      mockedExtract.mockReturnValue(ops);
+      mockedExtract.mockReturnValue(entitiesOf(ops));
       mockedReadSources.mockReturnValue([
         {
           file: 'src/gql/graphql.ts',
@@ -970,14 +1008,14 @@ describe('gqlPruner', () => {
       mockedDirExists.mockReturnValue(true);
       const ops = ['A', 'B', 'C', 'D', 'E'].map((name) => ({
         name,
-        type: 'query',
+        type: 'query' as const,
         filePath: 'a.gql',
         line: 1,
       }));
       mockedFind
         .mockReturnValueOnce(['a.gql'])
         .mockReturnValueOnce(['src/gql/graphql.ts']);
-      mockedExtract.mockReturnValue(ops);
+      mockedExtract.mockReturnValue(entitiesOf(ops));
       mockedReadSources.mockReturnValue([
         {
           file: 'src/gql/graphql.ts',
@@ -1001,10 +1039,12 @@ describe('gqlPruner', () => {
       mockedFind
         .mockReturnValueOnce(['a.gql'])
         .mockReturnValueOnce(['App.tsx']);
-      mockedExtract.mockReturnValue([
-        { name: 'GetUser', type: 'query', filePath: 'a.gql' },
-        { name: 'Dead', type: 'query', filePath: 'a.gql' },
-      ]);
+      mockedExtract.mockReturnValue(
+        entitiesOf([
+          { name: 'GetUser', type: 'query', filePath: 'a.gql' },
+          { name: 'Dead', type: 'query', filePath: 'a.gql' },
+        ]),
+      );
       mockedReadSources.mockReturnValue([
         { file: 'App.tsx', content: 'const r = useGetUserQuery()' },
       ]);
@@ -1029,9 +1069,11 @@ describe('gqlPruner', () => {
       mockedFind
         .mockReturnValueOnce(['a.gql'])
         .mockReturnValueOnce(['App.tsx']);
-      mockedExtract.mockReturnValue([
-        { name: 'GetUser', type: 'query', filePath: 'a.gql', line: 1 },
-      ]);
+      mockedExtract.mockReturnValue(
+        entitiesOf([
+          { name: 'GetUser', type: 'query', filePath: 'a.gql', line: 1 },
+        ]),
+      );
       mockedReadSources.mockReturnValue([
         { file: 'App.tsx', content: 'useGetUserQuery()' },
       ]);
@@ -1057,9 +1099,9 @@ describe('gqlPruner', () => {
       mockedFind
         .mockReturnValueOnce(['a.gql'])
         .mockReturnValueOnce(['App.tsx']);
-      mockedExtract.mockReturnValue([
-        { name: 'GetUser', type: 'query', filePath: 'a.gql' },
-      ]);
+      mockedExtract.mockReturnValue(
+        entitiesOf([{ name: 'GetUser', type: 'query', filePath: 'a.gql' }]),
+      );
       mockedReadSources.mockReturnValue([
         { file: 'App.tsx', content: 'useGetUserQuery()' },
       ]);
@@ -1081,9 +1123,9 @@ describe('gqlPruner', () => {
       mockedFind
         .mockReturnValueOnce(['a.gql'])
         .mockReturnValueOnce(['App.tsx']);
-      mockedExtract.mockReturnValue([
-        { name: 'GetUser', type: 'query', filePath: 'a.gql' },
-      ]);
+      mockedExtract.mockReturnValue(
+        entitiesOf([{ name: 'GetUser', type: 'query', filePath: 'a.gql' }]),
+      );
       mockedReadSources.mockReturnValue([
         { file: 'App.tsx', content: 'useGetUserQuery()' },
       ]);

--- a/test/operations.test.ts
+++ b/test/operations.test.ts
@@ -2,7 +2,6 @@ import * as fs from 'fs';
 import { parse } from 'graphql';
 import {
   extractGraphqlEntities,
-  extractOperations,
   getFragmentSpreads,
 } from '../src/utils/operations';
 
@@ -23,44 +22,6 @@ afterAll(() => {
 describe('operationUtils', () => {
   afterEach(() => {
     jest.resetAllMocks();
-  });
-
-  describe('extractOperations', () => {
-    it('should extract operations from a valid GraphQL file', () => {
-      (fs.readFileSync as jest.Mock).mockReturnValue(
-        'query MyQuery { someField }',
-      );
-
-      const operations = extractOperations('./mockFile.gql');
-      expect(operations).toEqual([
-        {
-          name: 'MyQuery',
-          type: 'query',
-          filePath: './mockFile.gql',
-          line: 1,
-        },
-      ]);
-    });
-
-    it('should handle invalid GraphQL content', () => {
-      const mockContent = `
-        query MyQuery {
-          someField
-      `;
-      (fs.readFileSync as jest.Mock).mockReturnValue(mockContent);
-
-      const operations = extractOperations('./mockFile.gql');
-      expect(operations).toEqual([]);
-    });
-
-    it('should handle error when reading a file', () => {
-      (fs.readFileSync as jest.Mock).mockImplementation(() => {
-        throw new Error('Failed to read file');
-      });
-
-      const operations = extractOperations('./mockFile.gql');
-      expect(operations).toEqual([]);
-    });
   });
 
   describe('getFragmentSpreads', () => {


### PR DESCRIPTION
Closes #67

## What

Two cleanups from the code-review backlog, no intended behavior change:

1. **Parse each `.gql`/`.graphql` file once per scan.** Previously `scanProject` parsed every file via `extractOperations`, and then `findUnusedFragmentsInCorpus` read and parsed the *same files again* via `extractGraphqlEntities` to build the fragment-spread graph. `scanProject` now calls `extractGraphqlEntities` once per file and shares the parsed entities with both the operation scan and the fragment scan — halving GraphQL file I/O and parse work, and removing the (theoretical) window where the two passes could disagree about a file's contents.

2. **Delete dead code.** `isOperationUsed` and `readFileContents` in `fileUtils.ts` were the pre-cache legacy path, referenced only by their own tests. `extractOperations` becomes unreferenced after (1) and goes with them. Net: **−72 lines** of source and tests.

## How

- `findUnusedFragmentsInCorpus(parsedFiles: GraphqlFileEntities[], fileContents, fragmentUsagePatterns)` — takes pre-parsed entities instead of file paths and no longer touches the filesystem at all, making it a pure function over parsed data (its tests now build entities explicitly via `extractGraphqlEntities` and exercise the same parse→graph pipeline as before).
- `scanProject`: `const parsedFiles = gqlFiles.map(extractGraphqlEntities)`; operations derive from `parsedFiles.flatMap(f => f.operations)`; `parsedFiles` feeds the fragment scan. `ScanResult` shape is unchanged.
- These are internal APIs (the package ships a CLI, not a library), so the signature change has no external consumers.

## How tested

- TDD: rewrote the fragment-corpus and scanProject specs to the new API first (red — compile-level signature failures), then implemented to green.
- New regression test pins the contract: `extractGraphqlEntities` is called **exactly once per gql file** and the very same parsed entities are handed to `findUnusedFragmentsInCorpus`.
- All fragment semantics tests (transitive spreads, duplicate-name merge + warning, masking references, cycles) pass unchanged on the new signature.
- Full local gate green: `npm run build && npm run typecheck && npm run lint && npm test` (195 tests — count is lower than before because the dead helpers' tests were deleted with them); coverage above thresholds (98.8% statements).
- Smoke-tested the compiled CLI on a fixture with operations + used/unused fragments: identical findings to before the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GraphQL scanning so operations and fragments are parsed from a shared representation, making unused-fragment detection more consistent.
  * Streamlined project analysis to avoid redundant parsing, which should improve reliability when working with GraphQL files.

* **Refactor**
  * Removed a few redundant helper paths and updated internal processing to use a single GraphQL entity extraction flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->