### PR TITLE
fix(init): confirm before overwriting an existing config; exit cleanly on Ctrl+C

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ npx gqlprune init
 ✓ Found 42 operations in 12 files; 5 look unused. Run "gqlprune" to see them.
 ```
 
+If a `gqlPrune.config.yaml` already exists, `init` asks before overwriting it (defaulting to **No**), so an existing hand-tuned config is never clobbered by accident.
+
 ```yaml
 graphqlDir: ./path/to/graphql
 srcDir: ./src

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,4 +63,13 @@ async function run(): Promise<void> {
   await notifyUpdate(pkg, { json });
 }
 
-void run();
+run().catch((error: unknown) => {
+  // Inquirer rejects with an ExitPromptError when the user aborts a prompt
+  // (Ctrl+C) — a deliberate exit, not a crash worth a stack trace.
+  if (error instanceof Error && error.name === 'ExitPromptError') {
+    console.error('Aborted.');
+  } else {
+    console.error(error);
+  }
+  process.exitCode = 1;
+});

--- a/src/core/configGenerator.ts
+++ b/src/core/configGenerator.ts
@@ -105,7 +105,27 @@ function printPreview(config: GqlPruneConfig): void {
   );
 }
 
+const CONFIG_FILE = './gqlPrune.config.yaml';
+
 export async function generateConfig() {
+  // Never clobber an existing (possibly hand-tuned) config without asking.
+  if (fs.existsSync(CONFIG_FILE)) {
+    const { overwrite } = (await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'overwrite',
+        message: 'gqlPrune.config.yaml already exists. Overwrite it?',
+        default: false,
+      },
+    ])) as { overwrite: boolean };
+    if (!overwrite) {
+      console.log(
+        'Keeping the existing gqlPrune.config.yaml — nothing was changed.',
+      );
+      return;
+    }
+  }
+
   const graphqlDefault = detectGraphqlDir() ?? './path/to/graphql';
   const srcDefault = detectSrcDir() ?? './path/to/src';
 
@@ -146,7 +166,7 @@ export async function generateConfig() {
   const answers = await inquirer.prompt(questions);
 
   // Write the answers to a configuration file
-  fs.writeFileSync('./gqlPrune.config.yaml', yaml.dump(answers));
+  fs.writeFileSync(CONFIG_FILE, yaml.dump(answers));
   console.log('Configuration generated successfully!');
 
   // Show an instant preview of what a real run would find.

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -16,7 +16,11 @@ describe('cli dispatch', () => {
     process.exitCode = 0; // error paths set exitCode; don't leak to the runner
   });
 
-  function runCli(args: string[], env: { GITHUB_ACTIONS?: string } = {}) {
+  function runCli(
+    args: string[],
+    env: { GITHUB_ACTIONS?: string } = {},
+    initError?: Error,
+  ) {
     process.argv = ['node', 'cli', ...args];
     delete process.env.GITHUB_ACTIONS;
     if (env.GITHUB_ACTIONS !== undefined) {
@@ -29,7 +33,11 @@ describe('cli dispatch', () => {
     };
     jest.isolateModules(() => {
       jest.doMock('../src/core/configGenerator', () => ({
-        generateConfig: jest.fn(),
+        generateConfig: jest
+          .fn()
+          .mockImplementation(() =>
+            initError ? Promise.reject(initError) : Promise.resolve(),
+          ),
       }));
       // Partial mock: cli.ts also imports the real escapeAnnotationMessage.
       jest.doMock('../src/core/gqlPruner', () => ({
@@ -220,6 +228,36 @@ describe('cli dispatch', () => {
     expect(errorSpy.mock.calls.flat().join('\n')).toContain(
       '::error::Unknown flag: --50%25off',
     );
+    errorSpy.mockRestore();
+  });
+
+  it('exits cleanly when an init prompt is aborted (Ctrl+C)', async () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    // inquirer rejects with an ExitPromptError when the user aborts a prompt.
+    const abort = new Error('User force closed the prompt');
+    abort.name = 'ExitPromptError';
+    runCli(['init'], {}, abort);
+    await new Promise(process.nextTick); // let run()'s catch handler settle
+
+    const errs = errorSpy.mock.calls.flat();
+    expect(errs).toContain('Aborted.');
+    expect(errs).not.toContain(abort); // no stack trace for a deliberate exit
+    expect(process.exitCode).toBe(1);
+    errorSpy.mockRestore();
+  });
+
+  it('reports an unexpected init failure and exits 1', async () => {
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    const failure = new Error('disk full');
+    runCli(['init'], {}, failure);
+    await new Promise(process.nextTick);
+
+    expect(errorSpy.mock.calls.flat()).toContain(failure);
+    expect(process.exitCode).toBe(1);
     errorSpy.mockRestore();
   });
 

--- a/test/configGenerator.test.ts
+++ b/test/configGenerator.test.ts
@@ -159,6 +159,58 @@ describe('configGenerator', () => {
 
     afterEach(() => logSpy.mockRestore());
 
+    it('asks before overwriting an existing config and keeps it when declined', async () => {
+      mockFsTree({ '.': [] }, new Set());
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      (inquirer.prompt as unknown as jest.Mock).mockResolvedValueOnce({
+        overwrite: false,
+      });
+
+      await generateConfig();
+
+      expect(inquirer.prompt).toHaveBeenCalledTimes(1); // confirm only
+      const [confirm] = (inquirer.prompt as unknown as jest.Mock).mock
+        .calls[0][0];
+      expect(confirm.type).toBe('confirm');
+      expect(confirm.default).toBe(false);
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+      expect(logSpy.mock.calls.flat().join('\n')).toContain('existing');
+    });
+
+    it('overwrites an existing config when the user confirms', async () => {
+      mockFsTree({ '.': [] }, new Set());
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+      (inquirer.prompt as unknown as jest.Mock)
+        .mockResolvedValueOnce({ overwrite: true })
+        .mockResolvedValueOnce({
+          graphqlDir: './graphql',
+          srcDir: './src',
+          exclude: [],
+        });
+
+      await generateConfig();
+
+      expect(inquirer.prompt).toHaveBeenCalledTimes(2);
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not ask for confirmation when no config exists', async () => {
+      mockFsTree({ '.': [] }, new Set());
+      (fs.existsSync as jest.Mock).mockReturnValue(false);
+      (inquirer.prompt as unknown as jest.Mock).mockResolvedValue({
+        graphqlDir: './graphql',
+        srcDir: './src',
+        exclude: [],
+      });
+
+      await generateConfig();
+
+      expect(inquirer.prompt).toHaveBeenCalledTimes(1);
+      const questions = (inquirer.prompt as unknown as jest.Mock).mock
+        .calls[0][0];
+      expect(questions[0].name).toBe('graphqlDir'); // straight to the questions
+    });
+
     it('prompts the user and writes the answers as YAML', async () => {
       mockFsTree({ '.': [] }, new Set());
       (inquirer.prompt as unknown as jest.Mock).mockResolvedValue({


### PR DESCRIPTION
Closes #69

## What

Two init-experience fixes from the code-review backlog:

1. **Overwrite confirmation.** `gqlprune init` in a project that already has a `gqlPrune.config.yaml` now asks *"gqlPrune.config.yaml already exists. Overwrite it?"* (default **No**) before doing anything else. Declining leaves the file untouched and prints a one-liner. Previously a stray `init` silently clobbered a hand-tuned config — custom patterns, excludes, everything.

2. **Clean abort on Ctrl+C.** `cli.ts` fired `void run()` with no rejection handler; inquirer v14 rejects with `ExitPromptError` when the user aborts a prompt, so Ctrl+C during init dumped an unhandled-rejection stack trace and crashed Node. `run()` now has a `.catch`: a deliberate abort prints `Aborted.` (no stack trace), any other unexpected rejection is reported to stderr, and both set exit code 1.

## How

- The confirm prompt runs before the directory-detection work, so declining is instant.
- The catch matches on `error.name === 'ExitPromptError'` rather than importing the class, keeping `cli.ts` decoupled from inquirer internals (the config generator is the only module that owns that dependency).
- README documents the new confirmation behavior in the Configuration section.

## How tested

- TDD, red first. The Ctrl+C test was satisfyingly dramatic in the red phase: the unhandled rejection **crashed the Jest worker process outright** — the exact failure users hit.
- New tests: decline path (confirm prompt shown with `default: false`, no `writeFileSync`, "existing" message), confirm path (proceeds to the normal questions and writes), no-config path (no confirmation prompt, straight to questions), `ExitPromptError` → `Aborted.` with no stack trace + exit 1, generic init failure → error reported + exit 1.
- Full local gate green: `npm run build && npm run typecheck && npm run lint && npm test` (200 tests), coverage above thresholds (`cli.ts` and `configGenerator.ts` both at 100% statements).
- Smoke-tested the compiled CLI: SIGINT mid-prompt prints `Aborted.` and exits 1 with the config intact (previously: stack trace). Non-TTY stdin also aborts cleanly. The interactive yes/no branches are pinned by the unit tests — macOS `script`(1) closes stdin before inquirer attaches, so those paths can't be driven from a pipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)