### PR TITLE
chore(ci): tame CodeRabbit review volume (hourly rate limit)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,19 @@
+# CodeRabbit configuration — tames review volume so a burst of small PRs
+# doesn't hit the hourly review rate limit.
+# Schema/docs: https://docs.coderabbit.ai/configuration/auto-review
+#
+# NOTE: this file takes precedence over the organization UI settings for this
+# repo, so the review profile is restated here.
+reviews:
+  profile: chill
+  auto_review:
+    enabled: true
+    # One auto review when the PR opens. Pushes that address review comments
+    # do NOT re-trigger a review — when the fixes are ready for a re-check,
+    # request one explicitly by commenting "@coderabbitai review".
+    auto_incremental_review: false
+    # Machine-generated PRs with nothing meaningful to review.
+    ignore_title_keywords:
+      - "chore(main): release"
+    ignore_usernames:
+      - "dependabot[bot]"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,6 +6,11 @@
 # repo, so the review profile is restated here.
 reviews:
   profile: chill
+  # Quieter bot = fewer GitHub notification emails: no "currently reviewing"
+  # status comments and no walkthrough poems. The review findings themselves
+  # are unaffected.
+  review_status: false
+  poem: false
   auto_review:
     enabled: true
     # One auto review when the PR opens. Pushes that address review comments

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,20 @@ CodeRabbit auto-reviews the PR. When its comments land:
     change just to silence the bot.
 - Re-run the local gate after addressing comments. CI must be green before merge.
 
+**Mind the hourly review rate limit.** Reviews are budgeted per rolling hour, and
+`.coderabbit.yaml` is configured to spend them only where they matter:
+
+- **Incremental auto-reviews are off** — pushing fixes for review comments does
+  *not* trigger a re-review. When the fixes are ready for a re-check, request one
+  explicitly by commenting `@coderabbitai review`.
+- Prefer `@coderabbitai review` (incremental) over `@coderabbitai full review` —
+  a full review re-reads the entire diff and costs accordingly. Never manually
+  trigger a review when an auto review of the same commits already ran.
+- release-please PRs (`chore(main): release`) and dependabot PRs are excluded
+  from auto-review — don't request reviews on them either.
+- When working through a queue of PRs, space them out; several PRs opened within
+  the same hour can still exhaust the budget.
+
 ### 6. Keep the board up to date
 Treat the [project board](https://github.com/users/Krister-Johansson/projects/3)
 as the source of truth for status — update it as work moves, not only at the end.


### PR DESCRIPTION
Closes #71

## What

We hit CodeRabbit's hourly review rate limit while working through the improvement backlog (4 PRs in ~80 minutes). This PR spends the review budget only where it matters:

**`.coderabbit.yaml`** (new):
- `auto_incremental_review: false` — one auto review when a PR opens; pushes addressing review comments no longer trigger automatic re-reviews. Request a re-check explicitly with `@coderabbitai review` when fixes are ready. This was the biggest consumer: our fix-after-review flow was doubling (sometimes tripling) reviews per PR.
- `ignore_title_keywords: ["chore(main): release"]` — release-please PRs are machine-generated changelogs; nothing to review.
- `ignore_usernames: ["dependabot[bot]"]` — ditto for dependency bumps (two were auto-reviewed today).
- `profile: chill` restated — a repo config file **takes precedence over the org UI settings**, so the current profile must be pinned here or it would silently reset to default.

**Less notification email** (follow-up commit): `review_status: false` (no "currently reviewing" status comments) and `poem: false` — every bot comment fans out as a GitHub notification email, so fewer comments means a quieter inbox. Review findings are unaffected.

**CLAUDE.md**: documents the rules in the CodeRabbit section — request re-reviews manually after pushing fixes, prefer incremental `@coderabbitai review` over `full review` (a full review re-reads the whole diff; today's limit was partly a manual `full review` on top of an already-completed auto review), and space out PR bursts since the budget is a rolling hourly window.

## How tested

- Config verified against the current CodeRabbit docs schema (`reviews.auto_review.*` keys) and parses cleanly with js-yaml.
- No source changes — test suite still green (195 tests). CodeRabbit itself validates the config when this PR opens, which doubles as the end-to-end check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added review automation settings for the repository, including a calmer review profile, auto-review behavior, and exclusions for release and dependency updates.
* **Documentation**
  * Expanded contributor guidance with notes on review limits, when to request another check, and how to avoid overloading review capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->