### PR TITLE
fix(scan): terminate on symlink cycles in the file walker

### DIFF
--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -42,49 +42,66 @@ export function createExcludeMatcher(patterns: string[]): ExcludeMatcher {
  * any directory or file whose project-root-relative path is excluded by
  * `isExcluded`.
  *
+ * Directory symlinks are followed, but never into a real directory that was
+ * already walked (`visited` tracks real paths), so symlink cycles terminate
+ * and an aliased directory is scanned only once. Broken symlinks are logged
+ * and skipped.
+ *
  * @param {string} dir - The directory to start searching from.
  * @param {string[]} extensions - The list of file extensions to match.
  * @param {ExcludeMatcher} isExcluded - Predicate marking paths to skip.
+ * @param {Set<string>} visited - Real paths of directories already walked.
  * @returns {string[]} - The matching file paths.
  */
 export function findFilesWithExtension(
   dir: string,
   extensions: string[],
   isExcluded: ExcludeMatcher,
+  visited: Set<string> = new Set(),
 ): string[] {
   let files: string[] = [];
 
   try {
-    const items = fs.readdirSync(dir);
+    const realDir = fs.realpathSync(dir);
+    if (visited.has(realDir)) {
+      return files; // already walked (symlink cycle or aliased directory)
+    }
+    visited.add(realDir);
 
-    items.forEach((item) => {
-      const itemPath = path.join(dir, item);
-      let stat;
+    const items = fs.readdirSync(dir, { withFileTypes: true });
 
-      try {
-        stat = fs.statSync(itemPath);
-      } catch (error) {
-        console.error(`Error reading stats for: ${itemPath}`);
-        if (error instanceof Error) {
-          console.error(error.message);
-        } else {
-          console.error(error);
-        }
-        return; // Skip this item and continue with the next one
-      }
+    for (const item of items) {
+      const itemPath = path.join(dir, item.name);
 
       if (isExcluded(toRelativePosix(itemPath))) {
-        return; // Skip excluded directories and files
+        continue; // Skip excluded directories and files
       }
 
-      if (stat.isDirectory()) {
+      // Dirents answer isDirectory() without a per-entry stat; only a symlink
+      // needs a stat to learn what it points at.
+      let isDirectory = item.isDirectory();
+      if (item.isSymbolicLink()) {
+        try {
+          isDirectory = fs.statSync(itemPath).isDirectory();
+        } catch (error) {
+          console.error(`Error reading stats for: ${itemPath}`);
+          if (error instanceof Error) {
+            console.error(error.message);
+          } else {
+            console.error(error);
+          }
+          continue; // Broken symlink — skip it and continue with the next one
+        }
+      }
+
+      if (isDirectory) {
         files = files.concat(
-          findFilesWithExtension(itemPath, extensions, isExcluded),
+          findFilesWithExtension(itemPath, extensions, isExcluded, visited),
         );
-      } else if (extensions.includes(path.extname(item))) {
+      } else if (extensions.includes(path.extname(item.name))) {
         files.push(itemPath);
       }
-    });
+    }
   } catch (error) {
     console.error(`Error reading directory: ${dir}`);
     if (error instanceof Error) {

--- a/test/configGenerator.test.ts
+++ b/test/configGenerator.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import inquirer from 'inquirer';
 import {
   commonParentDir,
@@ -30,12 +31,19 @@ function mockFsTree(
   entries: Record<string, string[]>,
   dirs: Set<string>,
 ): void {
-  (fs.readdirSync as jest.Mock).mockImplementation(
-    (p: string) => entries[p] ?? [],
+  (fs.readdirSync as jest.Mock).mockImplementation((p: string) =>
+    (entries[p] ?? []).map((name) => ({
+      name,
+      isDirectory: () => dirs.has(path.join(p, name)),
+      isSymbolicLink: () => false,
+    })),
   );
   (fs.statSync as jest.Mock).mockImplementation((p: string) => ({
     isDirectory: () => dirs.has(p),
   }));
+  (fs.realpathSync as unknown as jest.Mock).mockImplementation(
+    (p: string) => p,
+  );
 }
 
 describe('configGenerator', () => {

--- a/test/fileUtils.test.ts
+++ b/test/fileUtils.test.ts
@@ -32,19 +32,36 @@ describe('fileUtils', () => {
       jest.resetAllMocks();
     });
 
+    // A minimal fs.Dirent stand-in, as returned by readdirSync withFileTypes.
+    const dirent = (
+      name: string,
+      opts: { dir?: boolean; link?: boolean } = {},
+    ) => ({
+      name,
+      isDirectory: () => opts.dir === true,
+      isSymbolicLink: () => opts.link === true,
+    });
+
+    // Unless a test says otherwise, every path is its own real path.
+    beforeEach(() => {
+      (fs.realpathSync as unknown as jest.Mock).mockImplementation(
+        (p: string) => p,
+      );
+    });
+
     it('should find files with the given extensions', () => {
-      (fs.readdirSync as jest.Mock).mockReturnValue([
-        'file1.ts',
-        'file2.js',
-        'folder1',
-      ]);
-      (fs.statSync as jest.Mock)
-        .mockReturnValueOnce({ isDirectory: () => false })
-        .mockReturnValueOnce({ isDirectory: () => false })
-        .mockReturnValueOnce({ isDirectory: () => true });
+      (fs.readdirSync as jest.Mock).mockImplementation((p: string) =>
+        p === './'
+          ? [
+              dirent('file1.ts'),
+              dirent('file2.js'),
+              dirent('folder1', { dir: true }),
+            ]
+          : [],
+      );
 
       const files = findFilesWithExtension('./', ['.ts'], () => false);
-      expect(files).toEqual(['file1.ts']); // Adjusted the expected value
+      expect(files).toEqual(['file1.ts']);
     });
 
     it('should handle error when reading a directory', () => {
@@ -56,35 +73,93 @@ describe('fileUtils', () => {
       expect(files).toEqual([]); // Expect an empty array since the directory read failed
     });
 
-    it('should handle error when reading stats for a file', () => {
-      (fs.readdirSync as jest.Mock).mockReturnValue(['file1.ts']);
-      (fs.statSync as jest.Mock).mockImplementation(() => {
-        throw new Error('Failed to read file stats');
-      });
+    it('follows a symlink to a directory outside the walked tree', () => {
+      (fs.readdirSync as jest.Mock).mockImplementation(
+        (p: string) =>
+          p === './' ? [dirent('alias', { link: true })] : [dirent('a.ts')], // contents behind the link
+      );
+      (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => true });
+      (fs.realpathSync as unknown as jest.Mock).mockImplementation(
+        (p: string) => (p === 'alias' ? '/real/target' : p),
+      );
 
-      const files = findFilesWithExtension('./', ['.ts'], () => false);
-      expect(files).toEqual([]); // Expect an empty array since the file stats read failed
+      expect(findFilesWithExtension('./', ['.ts'], () => false)).toEqual([
+        'alias/a.ts',
+      ]);
     });
 
-    it('should handle error when reading stats for a folder', () => {
-      (fs.readdirSync as jest.Mock).mockReturnValue(['folder1']);
+    it('follows a symlink directly to a matching file', () => {
+      (fs.readdirSync as jest.Mock).mockReturnValue([
+        dirent('linked.ts', { link: true }),
+      ]);
+      (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => false });
+
+      expect(findFilesWithExtension('./', ['.ts'], () => false)).toEqual([
+        'linked.ts',
+      ]);
+    });
+
+    it('skips a broken symlink and keeps walking', () => {
+      (fs.readdirSync as jest.Mock).mockReturnValue([
+        dirent('broken.ts', { link: true }),
+        dirent('good.ts'),
+      ]);
       (fs.statSync as jest.Mock).mockImplementation(() => {
-        throw new Error('Failed to read folder stats');
+        throw new Error('ENOENT: dangling link');
       });
 
-      const files = findFilesWithExtension('./', ['.ts'], () => false);
-      expect(files).toEqual([]); // Expect an empty array since the folder stats read failed
+      expect(findFilesWithExtension('./', ['.ts'], () => false)).toEqual([
+        'good.ts',
+      ]);
+    });
+
+    it('terminates on a symlink cycle instead of recursing forever', () => {
+      // `loop` points back at the directory being walked.
+      (fs.readdirSync as jest.Mock).mockReturnValue([
+        dirent('loop', { link: true }),
+        dirent('a.ts'),
+      ]);
+      (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => true });
+      (fs.realpathSync as unknown as jest.Mock).mockReturnValue(
+        '/the/same/dir',
+      );
+
+      expect(findFilesWithExtension('./', ['.ts'], () => false)).toEqual([
+        'a.ts',
+      ]);
+      // The cycle is pruned before re-reading: one readdir for the root only.
+      expect(fs.readdirSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not scan the same real directory twice via an alias symlink', () => {
+      (fs.readdirSync as jest.Mock).mockImplementation((p: string) =>
+        p === './'
+          ? [dirent('real', { dir: true }), dirent('alias', { link: true })]
+          : p === 'real'
+            ? [dirent('a.ts')]
+            : [dirent('a.ts')],
+      );
+      (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => true });
+      (fs.realpathSync as unknown as jest.Mock).mockImplementation(
+        (p: string) => (p === 'real' || p === 'alias' ? '/canonical' : p),
+      );
+
+      // a.ts is reported once (under the path walked first), not twice.
+      expect(findFilesWithExtension('./', ['.ts'], () => false)).toEqual([
+        'real/a.ts',
+      ]);
     });
 
     it('skips excluded directories and files via the matcher', () => {
-      (fs.readdirSync as jest.Mock).mockReturnValue([
-        'keep.ts',
-        'node_modules',
-        'skip.gen.ts',
-      ]);
-      (fs.statSync as jest.Mock).mockImplementation((p: string) => ({
-        isDirectory: () => p.endsWith('node_modules'),
-      }));
+      (fs.readdirSync as jest.Mock).mockImplementation((p: string) =>
+        p === './'
+          ? [
+              dirent('keep.ts'),
+              dirent('node_modules', { dir: true }),
+              dirent('skip.gen.ts'),
+            ]
+          : [],
+      );
       const matcher = createExcludeMatcher(['node_modules', '*.gen.ts']);
       expect(findFilesWithExtension('./', ['.ts'], matcher)).toEqual([
         'keep.ts',
@@ -93,11 +168,10 @@ describe('fileUtils', () => {
 
     it('honors file-level "!" re-includes during the walk', () => {
       (fs.readdirSync as jest.Mock).mockReturnValue([
-        'foo.gen.ts',
-        'keep.gen.ts',
-        'app.ts',
+        dirent('foo.gen.ts'),
+        dirent('keep.gen.ts'),
+        dirent('app.ts'),
       ]);
-      (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => false });
       const matcher = createExcludeMatcher(['*.gen.ts', '!keep.gen.ts']);
       expect(findFilesWithExtension('./', ['.ts'], matcher).sort()).toEqual([
         'app.ts',
@@ -106,10 +180,9 @@ describe('fileUtils', () => {
     });
 
     it('cannot re-include under an excluded directory (gitignore limitation)', () => {
-      (fs.readdirSync as jest.Mock).mockReturnValue(['gen', 'app.ts']);
-      (fs.statSync as jest.Mock).mockImplementation((p: string) => ({
-        isDirectory: () => p.endsWith('gen'),
-      }));
+      (fs.readdirSync as jest.Mock).mockImplementation((p: string) =>
+        p === './' ? [dirent('gen', { dir: true }), dirent('app.ts')] : [],
+      );
       // `gen` is pruned before traversal, so `!gen/keep.ts` can't reach inside.
       const matcher = createExcludeMatcher(['gen', '!gen/keep.ts']);
       expect(findFilesWithExtension('./', ['.ts'], matcher)).toEqual([


### PR DESCRIPTION
Closes #73

## What

`findFilesWithExtension` hung forever when the scanned tree contained a directory symlink pointing back at an ancestor (`src/loop -> ..`): `fs.statSync` follows symlinks, so the walker recursed until the path exceeded system limits. Any project with such a link — not exotic in monorepos and pnpm setups — would see `gqlprune` freeze with no output.

## How

- Entries are read with `readdirSync(dir, { withFileTypes: true })`; dirents answer `isDirectory()`/`isSymbolicLink()` directly, so regular entries no longer cost a `stat` each (one syscall per directory instead of one per entry — a modest speedup on large trees).
- Directory symlinks are **still followed** (no behavior regression for projects with symlinked source dirs), but the walker tracks the `fs.realpathSync` of every directory it enters and refuses to walk the same real directory twice. Cycles terminate, and an alias to an already-walked directory no longer produces duplicate findings.
- Broken symlinks are logged and skipped, consistent with the existing unreadable-entry handling.
- The `visited` set is an optional trailing parameter with a default, so the exported signature stays backward-compatible.

## How tested

- TDD: the walker specs were rewritten to dirent-based mocks first (12 red), then implemented to green. New specs pin: cycle termination (with an exact `readdirSync` call-count assertion proving the cycle is pruned before re-reading), following a non-cyclic symlinked directory, following a symlink to a matching file, alias dedup (file reported once, not twice), and broken-symlink skip.
- `mockFsTree` in the configGenerator tests (which drives the real walker) updated to the dirent shape; all detection tests pass unchanged.
- Full local gate green: `npm run build && npm run typecheck && npm run lint && npm test` (203 tests), coverage above thresholds.
- End-to-end on real disk: a fixture with an actual `ln -s ..` cycle plus an alias symlink. The compiled CLI completes instantly, counts each real directory once (verified via `--verbose`), and reports correct results — the pre-fix build recurses indefinitely on the same fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File scanning now follows directory symlinks safely, while avoiding duplicate scans and symlink loops.
  * Broken symlinks are skipped without stopping the rest of the traversal.

* **Bug Fixes**
  * Directory searches now handle linked folders and files more reliably.
  * Exclusion rules continue to apply during traversal, including when paths are resolved through symlinks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->