### PR TITLE
feat(cli): exit 2 on usage/config errors, reserving exit 1 for findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,9 @@ npx gqlprune
 
 This prints any unused GraphQL operations and fragments. The command exits with:
 
-- **0** when nothing unused is found (suitable for CI gates).
-- **1** when unused operations or fragments are found (or on configuration errors).
+- **0** when the scan completes and nothing unused is found (suitable for CI gates).
+- **1** when the scan completes and unused operations or fragments are found — exit code 1 always means findings, nothing else.
+- **2** when the run itself fails: an unknown flag or command, a flag missing its value, no configuration, an unreadable config file, or a configured directory that doesn't exist. This lets a pipeline tell "clean up your GraphQL" (1) apart from "fix the pipeline" (2).
 
 Print the installed version with `gqlprune --version` (or `-v`), and the full list of commands and flags with `gqlprune --help` (or `-h`).
 
@@ -168,7 +169,7 @@ npx gqlprune --json
 }
 ```
 
-Only the JSON is written to stdout and the exit code is unchanged (0 clean / 1 unused), so it pipes cleanly into `jq` and CI gates. The `warnings` array carries advisory messages — currently a heads-up when a [generated file may be masking results](#avoiding-false-all-clear-results) — and is empty when there are none.
+Only the JSON is written to stdout and the exit code is unchanged (0 clean / 1 unused / 2 error — see [Usage](#usage)), so it pipes cleanly into `jq` and CI gates. The `warnings` array carries advisory messages — currently a heads-up when a [generated file may be masking results](#avoiding-false-all-clear-results) — and is empty when there are none.
 
 ### Verbose output
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,9 +11,10 @@ const { command, json, annotate, version, verbose, help, errors, config } =
 const annotateMode = annotate || process.env.GITHUB_ACTIONS === 'true';
 
 /**
- * Prints usage errors and the --help pointer; the run is aborted. In CI /
- * --annotate mode each error is an (escaped) ::error workflow command so it
- * surfaces in the Actions UI instead of only in the raw log.
+ * Prints usage errors and the --help pointer; the run is aborted with exit
+ * code 2 (1 is reserved for "unused operations found"). In CI / --annotate
+ * mode each error is an (escaped) ::error workflow command so it surfaces in
+ * the Actions UI instead of only in the raw log.
  */
 function reportUsageErrors(lines: string[]): void {
   for (const line of lines) {
@@ -24,7 +25,7 @@ function reportUsageErrors(lines: string[]): void {
     );
   }
   console.error('Run "gqlprune --help" for usage.');
-  process.exitCode = 1;
+  process.exitCode = 2;
 }
 
 async function run(): Promise<void> {
@@ -71,5 +72,6 @@ run().catch((error: unknown) => {
   } else {
     console.error(error);
   }
-  process.exitCode = 1;
+  // 2, like other non-finding failures — 1 means "unused operations found".
+  process.exitCode = 2;
 });

--- a/src/core/gqlPruner.ts
+++ b/src/core/gqlPruner.ts
@@ -588,7 +588,7 @@ export function mainFunction(
   } catch (e) {
     console.error(kleur.red('Error reading gqlPrune.config.yaml.'));
     console.error(e);
-    process.exit(1);
+    process.exit(2);
   }
 
   const graphqlDirs = resolveDirs(resolved.graphqlDir);
@@ -600,7 +600,7 @@ export function mainFunction(
         'No configuration found. Create gqlPrune.config.yaml (run "gqlprune init") or pass --graphql <dir> and --src <dir>.',
       ),
     );
-    process.exit(1);
+    process.exit(2);
   }
 
   const missingDirs = [...graphqlDirs, ...srcDirs].filter(
@@ -612,7 +612,7 @@ export function mainFunction(
         `These configured directories do not exist: ${missingDirs.join(', ')}.`,
       ),
     );
-    process.exit(1);
+    process.exit(2);
   }
 
   // All directories exist; carry the normalized lists forward.

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -248,7 +248,7 @@ describe('cli dispatch', () => {
     errorSpy.mockRestore();
   });
 
-  it('reports an unexpected init failure and exits 1', async () => {
+  it('reports an unexpected init failure and exits 2', async () => {
     const errorSpy = jest
       .spyOn(console, 'error')
       .mockImplementation(() => undefined);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -178,7 +178,7 @@ describe('cli dispatch', () => {
     expect(errs).toContain('--help');
     expect(mainFunction).not.toHaveBeenCalled();
     expect(notifyUpdate).not.toHaveBeenCalled();
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(2);
     errorSpy.mockRestore();
   });
 
@@ -191,7 +191,7 @@ describe('cli dispatch', () => {
       'Missing value for --graphql',
     );
     expect(mainFunction).not.toHaveBeenCalled();
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(2);
     errorSpy.mockRestore();
   });
 
@@ -204,7 +204,7 @@ describe('cli dispatch', () => {
       '::error::Unknown flag: --jsn',
     );
     expect(mainFunction).not.toHaveBeenCalled();
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(2);
     errorSpy.mockRestore();
   });
 
@@ -244,7 +244,7 @@ describe('cli dispatch', () => {
     const errs = errorSpy.mock.calls.flat();
     expect(errs).toContain('Aborted.');
     expect(errs).not.toContain(abort); // no stack trace for a deliberate exit
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(2);
     errorSpy.mockRestore();
   });
 
@@ -257,7 +257,7 @@ describe('cli dispatch', () => {
     await new Promise(process.nextTick);
 
     expect(errorSpy.mock.calls.flat()).toContain(failure);
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(2);
     errorSpy.mockRestore();
   });
 
@@ -271,7 +271,7 @@ describe('cli dispatch', () => {
     expect(errs).toContain('--help');
     expect(mainFunction).not.toHaveBeenCalled();
     expect(generateConfig).not.toHaveBeenCalled();
-    expect(process.exitCode).toBe(1);
+    expect(process.exitCode).toBe(2);
     errorSpy.mockRestore();
   });
 });

--- a/test/gqlPruner.test.ts
+++ b/test/gqlPruner.test.ts
@@ -760,37 +760,37 @@ describe('gqlPruner', () => {
       process.exitCode = 0; // report paths set exitCode; don't leak to the runner
     });
 
-    it('exits 1 when the config file cannot be read', () => {
+    it('exits 2 when the config file cannot be read', () => {
       (fs.readFileSync as jest.Mock).mockImplementation(() => {
         throw new Error('no file');
       });
-      expect(() => mainFunction()).toThrow('process.exit:1');
-      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(() => mainFunction()).toThrow('process.exit:2');
+      expect(exitSpy).toHaveBeenCalledWith(2);
     });
 
-    it('exits 1 when the GraphQL directory does not exist', () => {
+    it('exits 2 when the GraphQL directory does not exist', () => {
       (fs.readFileSync as jest.Mock).mockReturnValue(
         'graphqlDir: ./g\nsrcDir: ./s\n',
       );
       mockedDirExists.mockReturnValueOnce(false); // graphqlDir missing
-      expect(() => mainFunction()).toThrow('process.exit:1');
+      expect(() => mainFunction()).toThrow('process.exit:2');
       expect(errorSpy).toHaveBeenCalled();
     });
 
-    it('exits 1 when the source directory does not exist', () => {
+    it('exits 2 when the source directory does not exist', () => {
       (fs.readFileSync as jest.Mock).mockReturnValue(
         'graphqlDir: ./g\nsrcDir: ./s\n',
       );
       mockedDirExists.mockReturnValueOnce(true).mockReturnValueOnce(false);
-      expect(() => mainFunction()).toThrow('process.exit:1');
+      expect(() => mainFunction()).toThrow('process.exit:2');
     });
 
-    it('exits 1 and names a missing directory in an array config', () => {
+    it('exits 2 and names a missing directory in an array config', () => {
       (fs.readFileSync as jest.Mock).mockReturnValue(
         'graphqlDir:\n  - ./g1\n  - ./g2\nsrcDir: ./s\n',
       );
       mockedDirExists.mockImplementation((dir: string) => dir !== './g2');
-      expect(() => mainFunction()).toThrow('process.exit:1');
+      expect(() => mainFunction()).toThrow('process.exit:2');
       expect(errorSpy.mock.calls.flat().join('\n')).toContain('./g2');
     });
 
@@ -1137,14 +1137,14 @@ describe('gqlPruner', () => {
       expect(logged()).toContain('No unused');
     });
 
-    it('exits 1 with guidance when neither a config file nor flags supply dirs', () => {
+    it('exits 2 with guidance when neither a config file nor flags supply dirs', () => {
       (fs.readFileSync as jest.Mock).mockImplementation(() => {
         const err = new Error('missing') as NodeJS.ErrnoException;
         err.code = 'ENOENT';
         throw err;
       });
 
-      expect(() => mainFunction()).toThrow('process.exit:1');
+      expect(() => mainFunction()).toThrow('process.exit:2');
       const errs = errorSpy.mock.calls.flat().join('\n');
       expect(errs).toContain('--graphql');
     });


### PR DESCRIPTION
Closes #75

## What

Adopts the grep/getopt exit-code convention so pipelines can tell "clean up your GraphQL" apart from "fix your pipeline":

| Code | Meaning |
| ---- | ------- |
| 0 | Scan completed, nothing unused (also `--help`, `--version`, successful `init`) |
| 1 | Scan completed, **unused operations/fragments found** — findings only, nothing else |
| 2 | The run itself failed: unknown flag/command, flag missing its value, no configuration, unreadable config file, configured directory doesn't exist, aborted init (Ctrl+C), unexpected errors |

Previously all of column 2 exited 1, indistinguishable from findings.

## Semver call for the maintainer

This is shipped as `feat` (minor). The old README did document exit 1 as covering "configuration errors", so a consumer explicitly checking `exit == 1` to mean *anything other than findings* would see 2 now. Plain non-zero gating (`gqlprune || fail`, the documented CI recipe) is unaffected. If you'd rather treat the error-path change as breaking, say so and I'll amend the commit to `feat!:` so release-please cuts 3.0.0 instead.

## How

- `mainFunction`: the three config-validation exits (`unreadable config`, `no configuration`, `missing directories`) go from `process.exit(1)` to `process.exit(2)`. Finding paths still set `exitCode = 1`.
- `cli.ts`: `reportUsageErrors` and the `run().catch` handler set `exitCode = 2`.
- README documents the three-code contract in Usage and the `--json` section.

## How tested

- TDD: flipped 11 error-path expectations to exit 2 first (red), then implemented. Finding-path tests still pin exit 1 and clean-path tests pin 0 — the full matrix is asserted.
- Full local gate green: `npm run build && npm run typecheck && npm run lint && npm test` (203 tests), coverage unchanged.
- End-to-end on the compiled CLI: findings → 1, clean scan → 0, unknown flag → 2, unknown command → 2, missing directory → 2, `--help` → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the usage and JSON output docs to clarify exit codes and error reporting behavior.
* **Bug Fixes**
  * Changed several command-line and configuration failure cases to exit with code **2**.
  * Kept exit code **1** reserved for unused findings.
  * Preserved existing JSON-only stdout behavior when `--json` is used.
* **Tests**
  * Adjusted test expectations to match the updated exit-code handling for CLI and configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->