### PR TITLE
feat(scan): warn on duplicate names; surface all advisory warnings in JSON

### DIFF
--- a/src/core/gqlPruner.ts
+++ b/src/core/gqlPruner.ts
@@ -18,7 +18,10 @@ import {
   DEFAULT_FRAGMENT_USAGE_PATTERNS,
   DEFAULT_USAGE_PATTERNS,
 } from '../utils/usagePatterns.js';
-import { extractGraphqlEntities } from '../utils/operations.js';
+import {
+  extractGraphqlEntities,
+  GraphqlFileEntities,
+} from '../utils/operations.js';
 import { findUnusedFragmentsInCorpus } from '../utils/fragments.js';
 
 // Folders that are always excluded from traversal, regardless of config.
@@ -418,6 +421,47 @@ export function formatGeneratedFileWarnings(
 }
 
 /**
+ * Advisory warnings for operation/fragment names defined more than once across
+ * the parsed corpus. Detection is name-keyed, so duplicate definitions are
+ * conflated — every definition shares one used/unused verdict. Returned as
+ * data so the caller can route them per the I/O rules (stderr + the JSON
+ * `warnings` array), like the generated-file warnings.
+ */
+export function findDuplicateNameWarnings(
+  parsedFiles: GraphqlFileEntities[],
+): string[] {
+  const duplicates = (
+    kind: 'operation' | 'fragment',
+    definitions: { name: string; filePath: string }[],
+  ): string[] => {
+    const filesByName = new Map<string, string[]>();
+    for (const { name, filePath } of definitions) {
+      filesByName.set(name, [...(filesByName.get(name) ?? []), filePath]);
+    }
+    return [...filesByName]
+      .filter(([, files]) => files.length > 1)
+      .map(
+        ([name, files]) =>
+          `Duplicate ${kind} name "${name}" defined in ${[
+            ...new Set(files),
+          ].join(
+            ', ',
+          )} — detection is name-based, so all definitions share one verdict and results for it may be unreliable.`,
+      );
+  };
+  return [
+    ...duplicates(
+      'operation',
+      parsedFiles.flatMap((file) => file.operations),
+    ),
+    ...duplicates(
+      'fragment',
+      parsedFiles.flatMap((file) => file.fragments),
+    ),
+  ];
+}
+
+/**
  * Loads configuration from `gqlPrune.config.yaml` (if present) and overlays the
  * values provided as CLI flags, which win per field. A missing config file is
  * fine — the CLI flags may supply everything. Throws on a malformed or
@@ -456,6 +500,8 @@ export type ScanResult = {
   operationUsages: OperationUsage[];
   unusedOperations: OperationInfo[];
   unusedFragments: FragmentInfo[];
+  /** Advisory duplicate-name warnings (operations and fragments). */
+  duplicateWarnings: string[];
   generatedWarnings: string[];
   /** Raw suspected-generated files, so callers can act on the paths (e.g.
    * `gqlprune init` pre-filling them into `exclude`), not just the messages. */
@@ -559,6 +605,7 @@ export function scanProject(config: GqlPruneConfig): ScanResult {
     operationUsages,
     unusedOperations,
     unusedFragments,
+    duplicateWarnings: findDuplicateNameWarnings(parsedFiles),
     generatedWarnings: formatGeneratedFileWarnings(generatedFiles),
     generatedFiles,
   };
@@ -635,8 +682,12 @@ export function mainFunction(
     operationCount,
     unusedOperations,
     unusedFragments,
+    duplicateWarnings,
     generatedWarnings,
   } = result;
+  // All advisory warnings share one pipeline: stderr lines (or ::warning in
+  // annotate mode) plus the JSON report's `warnings` array.
+  const advisoryWarnings = [...duplicateWarnings, ...generatedWarnings];
 
   if (verbose) {
     logVerbose(formatVerboseScanLines(result));
@@ -658,7 +709,7 @@ export function mainFunction(
   // output): it would silently make every operation look "used" and report
   // nothing unused. Emit to stderr so it surfaces in --json mode too without
   // corrupting the JSON on stdout.
-  for (const line of generatedWarnings) {
+  for (const line of advisoryWarnings) {
     // In CI, surface it as an (escaped) ::warning workflow command like the other
     // annotations; otherwise a coloured stderr line for humans.
     console.error(
@@ -678,7 +729,7 @@ export function mainFunction(
   if (json) {
     console.log(
       JSON.stringify(
-        buildJsonReport(unusedOperations, unusedFragments, generatedWarnings),
+        buildJsonReport(unusedOperations, unusedFragments, advisoryWarnings),
         null,
         2,
       ),

--- a/src/utils/fragments.ts
+++ b/src/utils/fragments.ts
@@ -76,21 +76,12 @@ export function findUnusedFragmentsInCorpus(
   const allFragments: FragmentInfo[] = [];
   const fragmentSpreads = new Map<string, string[]>();
   const roots = new Set<string>();
-  const seenFragmentNames = new Set<string>();
 
   for (const entities of parsedFiles) {
     entities.operationSpreads.forEach((spread) => roots.add(spread));
-    for (const fragment of entities.fragments) {
-      // Fragment names should be unique across the corpus. If they aren't, the
-      // graph is keyed by name, so warn rather than silently conflate them.
-      if (seenFragmentNames.has(fragment.name)) {
-        console.warn(
-          `Warning: duplicate fragment name "${fragment.name}" defined in multiple files; usage results may be approximate.`,
-        );
-      }
-      seenFragmentNames.add(fragment.name);
-      allFragments.push(fragment);
-    }
+    // Duplicate fragment names are reported by findDuplicateNameWarnings at the
+    // scan level; here they only need conservative graph handling (below).
+    allFragments.push(...entities.fragments);
     for (const { name, spreads } of entities.fragmentSpreads) {
       // Merge (not overwrite) so a duplicate definition cannot drop spread
       // edges — over-approximating reachability keeps results conservative.

--- a/test/fragments.test.ts
+++ b/test/fragments.test.ts
@@ -142,7 +142,7 @@ describe('fragments', () => {
       ).toEqual([]);
     });
 
-    it('warns on duplicate fragment names and merges their spread edges', () => {
+    it('merges spread edges of duplicate fragment names (conservative)', () => {
       // a.gql's Dupe spreads OnlyInA; b.gql's Dupe (same name) spreads nothing.
       // Without merging, the later definition would drop the edge to OnlyInA and
       // wrongly flag it as unused. Merging keeps it reachable (conservative).
@@ -161,9 +161,9 @@ describe('fragments', () => {
       );
 
       expect(unused.map((f) => f.name)).not.toContain('OnlyInA');
-      expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('duplicate fragment name "Dupe"'),
-      );
+      // Reporting duplicates is scanProject's job now (findDuplicateNameWarnings);
+      // this function only keeps the graph conservative.
+      expect(console.warn).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/gqlPruner.test.ts
+++ b/test/gqlPruner.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_EXCLUDED_FOLDERS,
   detectGeneratedFiles,
   explainOperationUsage,
+  findDuplicateNameWarnings,
   findUnusedOperations,
   formatAnnotations,
   formatGeneratedFileWarnings,
@@ -281,6 +282,7 @@ describe('gqlPruner', () => {
       gqlFiles: ['graphql/user.gql'],
       unusedOperations: [],
       unusedFragments: [],
+      duplicateWarnings: [],
       generatedWarnings: [],
       generatedFiles: [],
     };
@@ -316,6 +318,73 @@ describe('gqlPruner', () => {
         operationUsages: [],
       });
       expect(lines.join('\n')).toContain('Source files scanned: 3');
+    });
+  });
+
+  describe('findDuplicateNameWarnings', () => {
+    const file = (
+      operations: { name: string; filePath: string }[] = [],
+      fragments: { name: string; filePath: string }[] = [],
+    ) => ({
+      operations: operations.map((op) => ({ ...op, type: 'query' as const })),
+      fragments,
+      operationSpreads: [],
+      fragmentSpreads: [],
+    });
+
+    it('warns when an operation name is defined in two files', () => {
+      const warnings = findDuplicateNameWarnings([
+        file([{ name: 'GetUser', filePath: 'a.gql' }]),
+        file([{ name: 'GetUser', filePath: 'b.gql' }]),
+      ]);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('operation');
+      expect(warnings[0]).toContain('"GetUser"');
+      expect(warnings[0]).toContain('a.gql');
+      expect(warnings[0]).toContain('b.gql');
+    });
+
+    it('warns on a duplicate defined twice within one file', () => {
+      const warnings = findDuplicateNameWarnings([
+        file([
+          { name: 'GetUser', filePath: 'a.gql' },
+          { name: 'GetUser', filePath: 'a.gql' },
+        ]),
+      ]);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('"GetUser"');
+    });
+
+    it('warns when a fragment name is defined in two files', () => {
+      const warnings = findDuplicateNameWarnings([
+        file([], [{ name: 'UserFields', filePath: 'a.gql' }]),
+        file([], [{ name: 'UserFields', filePath: 'b.gql' }]),
+      ]);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('fragment');
+      expect(warnings[0]).toContain('"UserFields"');
+    });
+
+    it('does not conflate an operation and a fragment sharing a name', () => {
+      expect(
+        findDuplicateNameWarnings([
+          file(
+            [{ name: 'User', filePath: 'a.gql' }],
+            [{ name: 'User', filePath: 'b.gql' }],
+          ),
+        ]),
+      ).toEqual([]);
+    });
+
+    it('returns [] when every name is unique', () => {
+      expect(
+        findDuplicateNameWarnings([
+          file(
+            [{ name: 'A', filePath: 'a.gql' }],
+            [{ name: 'B', filePath: 'a.gql' }],
+          ),
+        ]),
+      ).toEqual([]);
     });
   });
 
@@ -707,6 +776,24 @@ describe('gqlPruner', () => {
         file: 'App.tsx',
       });
       expect(result.operationUsages[1].match).toBeUndefined();
+    });
+
+    it('exposes duplicate-name warnings from the parsed corpus', () => {
+      mockedFind
+        .mockReturnValueOnce(['a.gql', 'b.gql']) // gql files
+        .mockReturnValueOnce(['App.tsx']); // source files
+      mockedExtract.mockReturnValue(
+        entitiesOf([{ name: 'GetUser', type: 'query', filePath: 'a.gql' }]),
+      );
+      mockedReadSources.mockReturnValue([
+        { file: 'App.tsx', content: 'useGetUserQuery()' },
+      ]);
+
+      // Both parsed files define GetUser (same mock for each) → duplicate.
+      const result = scanProject({ graphqlDir: './g', srcDir: './s' });
+
+      expect(result.duplicateWarnings).toHaveLength(1);
+      expect(result.duplicateWarnings[0]).toContain('"GetUser"');
     });
 
     it('exposes the raw detected generated files (for init auto-exclude)', () => {
@@ -1111,6 +1198,52 @@ describe('gqlPruner', () => {
       expect(errorSpy.mock.calls.flat().join('\n')).not.toContain(
         'found in App.tsx',
       );
+    });
+
+    it('reports duplicate-name warnings on stderr and in the JSON warnings array', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        'graphqlDir: ./g\nsrcDir: ./s\n',
+      );
+      mockedDirExists.mockReturnValue(true);
+      mockedFind
+        .mockReturnValueOnce(['a.gql', 'b.gql'])
+        .mockReturnValueOnce(['App.tsx']);
+      mockedExtract.mockReturnValue(
+        entitiesOf([{ name: 'GetUser', type: 'query', filePath: 'a.gql' }]),
+      );
+      mockedReadSources.mockReturnValue([
+        { file: 'App.tsx', content: 'useGetUserQuery()' },
+      ]);
+
+      mainFunction({ json: true });
+
+      const errs = errorSpy.mock.calls.flat().join('\n');
+      expect(errs).toContain('"GetUser"');
+
+      const report = JSON.parse(logged());
+      expect(report.warnings).toHaveLength(1);
+      expect(report.warnings[0]).toContain('"GetUser"');
+    });
+
+    it('emits duplicate-name warnings as escaped ::warning annotations in annotate mode', () => {
+      (fs.readFileSync as jest.Mock).mockReturnValue(
+        'graphqlDir: ./g\nsrcDir: ./s\n',
+      );
+      mockedDirExists.mockReturnValue(true);
+      mockedFind
+        .mockReturnValueOnce(['a.gql', 'b.gql'])
+        .mockReturnValueOnce(['App.tsx']);
+      mockedExtract.mockReturnValue(
+        entitiesOf([{ name: 'GetUser', type: 'query', filePath: 'a.gql' }]),
+      );
+      mockedReadSources.mockReturnValue([
+        { file: 'App.tsx', content: 'useGetUserQuery()' },
+      ]);
+
+      mainFunction({ annotate: true });
+
+      const errs = errorSpy.mock.calls.flat().join('\n');
+      expect(errs).toMatch(/::warning::.*GetUser/);
     });
 
     it('runs from CLI config when no config file exists', () => {


### PR DESCRIPTION
Closes #82

## What

Two backlog items that interlock:

1. **Duplicate operation names now warn.** Detection is name-based: two operations named `GetUser` expand to identical search strings, so all definitions share one used/unused verdict. Previously this was silent; fragments had a warning but operations didn't. Now both kinds warn, naming the defining files:

   ```text
   ⚠ Duplicate operation name "GetUser" defined in graphql/a.gql, graphql/b.gql — detection is name-based, so all definitions share one verdict and results for it may be unreliable.
   ```

2. **All advisory warnings now reach the JSON report.** The old duplicate-fragment warning was a bare `console.warn` inside `findUnusedFragmentsInCorpus` — stderr only, invisible to `--json` consumers, violating the repo's own I/O rule ("advisory warnings are also serialized into the JSON `warnings` array as data"). Duplicate-name warnings now flow through the same pipeline as the generated-file warnings: yellow stderr lines, escaped `::warning` workflow commands in annotate mode, and entries in `warnings` in the JSON report.

## How

- New pure `findDuplicateNameWarnings(parsedFiles)` in the scan core — groups operation and fragment definitions by name from the already-parsed entities (no extra parsing; this builds on the parse-once refactor from #68). Operations and fragments are grouped separately: an operation and a fragment sharing a name is fine and does not warn.
- `ScanResult` gains `duplicateWarnings: string[]` (additive); `mainFunction` concatenates them with `generatedWarnings` into one advisory pipeline.
- The `console.warn` and its `seenFragmentNames` bookkeeping are removed from `findUnusedFragmentsInCorpus`; its conservative spread-edge merging (the behavior that actually matters for correctness) is untouched and still covered by its own test.

## How tested

- TDD: red first. New specs for the pure detector (cross-file duplicate ops, same-file duplicates, duplicate fragments, op/fragment name collision does NOT warn, unique names → `[]`), `scanProject` exposing `duplicateWarnings`, and `mainFunction` routing (stderr + JSON `warnings` array in one test, escaped `::warning` in annotate mode in another). The old fragments test flips from "warns" to "does not warn itself" while keeping its merge assertion.
- Full local gate green: `npm run build && npm run typecheck && npm run lint && npm test` (211 tests), coverage above thresholds.
- Smoke-tested the compiled CLI on a fixture with `GetUser` defined in two files: correct warning on stderr in human mode, present in `warnings` with stdout still pure JSON in `--json`, and escaped `::warning` in `--annotate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added duplicate GraphQL name warnings to scan results, covering both operations and fragments.
  * Duplicate-name warnings now appear in JSON output, stderr warnings, and annotation output.

* **Bug Fixes**
  * Improved handling of duplicate fragment names by consolidating reachability checks and removing redundant warning behavior.
  * Clarified warning behavior so duplicate-name reporting is surfaced consistently in the main scan flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->